### PR TITLE
Fix/regex performance #215

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-redux": "^7.0.1",
     "react-scripts": "^2.1.8",
     "react-split-pane": "^0.1.87",
-    "react-string-replace": "^0.4.4",
     "react-test-renderer": "^16.8.4",
     "react-tooltip": "^3.10.0",
     "read-last-lines": "^1.6.0",

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -25,7 +25,7 @@ class LogViewer extends React.Component {
   };
 
   hasMatch = (line, regex) => {
-    return line.test(regex);
+    return regex.test(line);
   };
 
   scrollToBottom = (el, list) => {

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -25,15 +25,16 @@ class LogViewer extends React.Component {
   };
 
   hasMatch = (line, regex) => {
-    return line.search(regex) !== -1;
+    return line.test(regex);
   };
 
-  scrollToBottom = () => {
-    this.windowedList.current.scrollAround(this.props.liveLines.length);
+  scrollToBottom = (el, list) => {
+    el.scrollAround(list.length);
   };
 
   componentDidUpdate() {
-    if (this.props.tailSwitch) this.scrollToBottom();
+    if (this.props.tailSwitch)
+      this.scrollToBottom(this.windowedList.current, this.props.liveLines);
   }
 
   parseRegexInput = (input, escapeRegexPrefix) => {

--- a/src/js/view/components/TextHighlightRegex.js
+++ b/src/js/view/components/TextHighlightRegex.js
@@ -3,19 +3,34 @@ import reactStringReplace from 'react-string-replace';
 import * as TextHighlightRegexSC from '../styledComponents/TextHighlightRegexStyledComponents';
 
 class TextHighlightRegex extends React.Component {
-  highlightMatches = (text, regex) => {
-    const group = '(' + regex + ')'; //Parenthesis required for reactStringReplace to work properly
-    return reactStringReplace(text, new RegExp(group, 'gi'), (match, i) => {
-      return (
-        <TextHighlightRegexSC.HighlightMatch key={i}>
-          {match}
-        </TextHighlightRegexSC.HighlightMatch>
-      );
-    });
+  highlightMatches = (text, regexInput) => {
+    const regex = new RegExp(regexInput, 'gi');
+    let matches = text.match(regex);
+    let unmatches = text.split(regex);
+
+    let array = [];
+    let currentMatch = '';
+    for (let i = 0; i < matches.length; i++) {
+      if (unmatches[i] === '') {
+        currentMatch += matches[i];
+      } else {
+        array.push(this.toHighlightElement(currentMatch, i));
+        array.push(unmatches[i]);
+      }
+    }
+
+    array.push(this.toHighlightElement(currentMatch, unmatches.length - 1));
+    array.push(unmatches[unmatches.length - 1]);
+
+    return array;
   };
 
-  highlightText = (text, style) => {
-    return <span style={style}>{text}</span>;
+  toHighlightElement = (text, i) => {
+    return (
+      <TextHighlightRegexSC.HighlightMatch key={i}>
+        {text}
+      </TextHighlightRegexSC.HighlightMatch>
+    );
   };
 
   render() {

--- a/src/js/view/components/TextHighlightRegex.js
+++ b/src/js/view/components/TextHighlightRegex.js
@@ -4,38 +4,9 @@ import {
   HighlightMatch
 } from '../styledComponents/TextHighlightRegexStyledComponents';
 
+import { groupByMatches } from 'js/view/components/helpers/regexHelper';
+
 class TextHighlightRegex extends React.Component {
-  highlightMatches = (text, regex) => {
-    let array = [];
-    let result;
-    let input = text;
-
-    // read until no more matches
-    while (input && (result = regex.exec(input))) {
-      const textBeforeMatch = input.slice(0, result.index);
-      const match = result[0];
-
-      //if textBeforeMatch is '' it means there was no characters between this match and the previous match, so append it to the previous match
-      if (!textBeforeMatch && array.length > 0) {
-        array[array.length - 1].highlight += match;
-      } else if (match) {
-        //normal text are strings and higlighted items are wrapped in an object so that we can see what text got highlighted later
-        array.push(textBeforeMatch);
-        array.push({ highlight: match });
-      } else {
-        break; //can't do much if it matches ''
-      }
-
-      //update input without the text added
-      input = input.slice(textBeforeMatch.length + match.length);
-    }
-
-    //add the text after the last match
-    array.push(input.slice(0));
-
-    return array;
-  };
-
   toHighlightElement = (text, i) => {
     return <HighlightMatch key={i}>{text}</HighlightMatch>;
   };
@@ -43,13 +14,11 @@ class TextHighlightRegex extends React.Component {
   render() {
     return (
       <HighlightText color={this.props.color}>
-        {this.highlightMatches(this.props.text, this.props.regex).map(
-          (x, i) => {
-            return x.highlight || x.highlight === ''
-              ? this.toHighlightElement(x.highlight, i)
-              : x;
-          }
-        )}
+        {groupByMatches(this.props.text, this.props.regex).map((x, i) => {
+          return x.group || x.group === ''
+            ? this.toHighlightElement(x.group, i)
+            : x;
+        })}
       </HighlightText>
     );
   }

--- a/src/js/view/components/TextHighlightRegex.js
+++ b/src/js/view/components/TextHighlightRegex.js
@@ -7,26 +7,28 @@ class TextHighlightRegex extends React.Component {
     let result;
     let input = text;
 
+    // read until no more matches
     while ((result = regex.exec(input))) {
-      const nomatch = input.slice(0, result.index);
+      const textBeforeMatch = input.slice(0, result.index);
       const match = result[0];
 
-      if (!nomatch && array.length > 0) {
+      //if textBeforeMatch is '' it means there was no characters between this match and the previous match, so append it to the previous match
+      if (!textBeforeMatch && array.length > 0) {
         array[array.length - 1].highlight += match;
       } else {
-        array.push(nomatch);
+        //normal text are strings and higlighted items are wrapped in an object so that we can see what text got highlighted later
+        array.push(textBeforeMatch);
         array.push({ highlight: match });
       }
 
-      input = input.slice(nomatch.length + match.length);
+      //update input without the text added
+      input = input.slice(textBeforeMatch.length + match.length);
     }
 
+    //add the text after the last match
     array.push(input.slice(0));
 
-    console.log(array);
-    return array.map((x, i) => {
-      return x.highlight ? this.toHighlightElement(x.highlight, i) : x;
-    });
+    return array;
   };
 
   toHighlightElement = (text, i) => {
@@ -40,7 +42,11 @@ class TextHighlightRegex extends React.Component {
   render() {
     return (
       <TextHighlightRegexSC.HighlightText color={this.props.color}>
-        {this.highlightMatches(this.props.text, this.props.regex)}
+        {this.highlightMatches(this.props.text, this.props.regex).map(
+          (x, i) => {
+            return x.highlight ? this.toHighlightElement(x.highlight, i) : x;
+          }
+        )}
       </TextHighlightRegexSC.HighlightText>
     );
   }

--- a/src/js/view/components/TextHighlightRegex.js
+++ b/src/js/view/components/TextHighlightRegex.js
@@ -8,7 +8,7 @@ class TextHighlightRegex extends React.Component {
     let input = text;
 
     // read until no more matches
-    while ((result = regex.exec(input))) {
+    while (input && (result = regex.exec(input))) {
       const textBeforeMatch = input.slice(0, result.index);
       const match = result[0];
 
@@ -22,7 +22,7 @@ class TextHighlightRegex extends React.Component {
       }
 
       //update input without the text added
-      input = input.slice(textBeforeMatch.length + match.length);
+      input = input.slice(Math.max(1, textBeforeMatch.length + match.length));
     }
 
     //add the text after the last match

--- a/src/js/view/components/TextHighlightRegex.js
+++ b/src/js/view/components/TextHighlightRegex.js
@@ -15,14 +15,16 @@ class TextHighlightRegex extends React.Component {
       //if textBeforeMatch is '' it means there was no characters between this match and the previous match, so append it to the previous match
       if (!textBeforeMatch && array.length > 0) {
         array[array.length - 1].highlight += match;
-      } else {
+      } else if (match) {
         //normal text are strings and higlighted items are wrapped in an object so that we can see what text got highlighted later
         array.push(textBeforeMatch);
         array.push({ highlight: match });
+      } else {
+        break; //can't do much if it matches ''
       }
 
       //update input without the text added
-      input = input.slice(Math.max(1, textBeforeMatch.length + match.length));
+      input = input.slice(textBeforeMatch.length + match.length);
     }
 
     //add the text after the last match
@@ -44,7 +46,9 @@ class TextHighlightRegex extends React.Component {
       <TextHighlightRegexSC.HighlightText color={this.props.color}>
         {this.highlightMatches(this.props.text, this.props.regex).map(
           (x, i) => {
-            return x.highlight ? this.toHighlightElement(x.highlight, i) : x;
+            return x.highlight || x.highlight === ''
+              ? this.toHighlightElement(x.highlight, i)
+              : x;
           }
         )}
       </TextHighlightRegexSC.HighlightText>

--- a/src/js/view/components/helpers/regexHelper.js
+++ b/src/js/view/components/helpers/regexHelper.js
@@ -1,3 +1,10 @@
+/**
+ * Returns an array of strings and matches grouped together (if they are adjacent) with order preserved
+ * Grouped matches are in the form of an object with one field group { group: ''}
+ * A returned array can look like the following ['The quick brown ', { group: 'fox something something' }, ' ran over something something']
+ * @param {string} text
+ * @param {RegExp} regex
+ */
 export const groupByMatches = (text, regex) => {
   let array = [];
   let result;

--- a/src/js/view/components/helpers/regexHelper.js
+++ b/src/js/view/components/helpers/regexHelper.js
@@ -1,0 +1,30 @@
+export const groupByMatches = (text, regex) => {
+  let array = [];
+  let result;
+  let input = text;
+
+  // read until no more matches
+  while (input && (result = regex.exec(input))) {
+    const textBeforeMatch = input.slice(0, result.index);
+    const match = result[0];
+
+    //if textBeforeMatch is '' it means there was no characters between this match and the previous match, so append it to the previous match
+    if (!textBeforeMatch && array.length > 0) {
+      array[array.length - 1].group += match;
+    } else if (match) {
+      //normal text are strings and higlighted items are wrapped in an object so that we can see what text got highlighted later
+      array.push(textBeforeMatch);
+      array.push({ group: match });
+    } else {
+      break; //can't do much if it matches ''
+    }
+
+    //update input without the text added
+    input = input.slice(textBeforeMatch.length + match.length);
+  }
+
+  //add the text after the last match
+  array.push(input.slice(0));
+
+  return array;
+};


### PR DESCRIPTION
This pull request will improve the performance of highlighting matches in text

Previously there was a dependency on a function in an external package for regex react replace but this was rather slow
Previously the text would create <span> tags around every match meaning that if you tried to highlight '.' then there would be created a span around every character in the text

This is resolved by making our own function (groupByMatches) that loops through a string that groups adjacent matched substrings together.  Then TextHighlightRegex renders each _group_ in separate spans. A '.' regex will instead create a single span around the whole string. 