### PR TITLE
#267 reload and toggle development tools don't show in release

### DIFF
--- a/src/js/electron/menu.js
+++ b/src/js/electron/menu.js
@@ -1,6 +1,7 @@
 const { Menu } = require('electron');
 const { dialog } = require('electron');
 const engine = require('../engine/engine');
+const isDev = require('electron-is-dev');
 
 let webContents;
 let recentFilesObject = [];
@@ -74,24 +75,26 @@ const createTemplate = () => {
     {
       label: 'View',
       submenu: [
-        {
-          label: 'Reload',
-          accelerator: 'CmdOrCtrl+R',
-          click(item, focusedWindow) {
-            if (focusedWindow) focusedWindow.reload();
-          }
-        },
-        {
-          label: 'Toggle Developer Tools',
-          accelerator:
-            process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-          click(item, focusedWindow) {
-            if (focusedWindow) focusedWindow.webContents.toggleDevTools();
-          }
-        },
-        {
-          type: 'separator'
-        },
+        isDev
+          ? {
+              role: 'reload',
+              accelerator: 'CmdOrCtrl+R'
+            }
+          : {
+              role: 'reload',
+              visible: false,
+              enabled: false
+            },
+        isDev
+          ? {
+              role: 'toggleDevTools',
+              accelerator:
+                process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I'
+            }
+          : {
+              role: 'toggleDevTools',
+              visible: false
+            },
         {
           role: 'resetzoom'
         },

--- a/src/js/electron/menu.js
+++ b/src/js/electron/menu.js
@@ -77,8 +77,7 @@ const createTemplate = () => {
       submenu: [
         isDev
           ? {
-              role: 'reload',
-              accelerator: 'CmdOrCtrl+R'
+              role: 'reload'
             }
           : {
               role: 'reload',
@@ -87,9 +86,7 @@ const createTemplate = () => {
             },
         isDev
           ? {
-              role: 'toggleDevTools',
-              accelerator:
-                process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I'
+              role: 'toggleDevTools'
             }
           : {
               role: 'toggleDevTools',


### PR DESCRIPTION
#267 

When packaged reload and toggle development tools don't show.

Used roles instead of label after I read from electron docs: "It is best to specify role for any menu item that matches a standard role, rather than trying to manually implement the behavior in a click function. The built-in role behavior will give the best native experience."
further reading: https://electronjs.org/docs/api/menu-item

No test because isDev comes from electron-is-dev dependency therefore not ours to test