### PR TITLE
Fix/wrap lines variable height #272

### DIFF
--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -17,11 +17,11 @@ class LogViewer extends React.Component {
   }
 
   render() {
-    const highlightRegex = parseRegExp(
+    const highlightRegExp = parseRegExp(
       this.props.highlightInput,
       this.state.escapeRegexSequence
     );
-    const filterRegex = parseRegExp(
+    const filterRegExp = parseRegExp(
       this.props.filterInput,
       this.state.escapeRegexSequence
     );
@@ -42,8 +42,8 @@ class LogViewer extends React.Component {
           wrapLines={this.props.wrapLineOn}
           scrollToBottom={this.props.tailSwitch}
           lines={this.props.liveLines}
-          highlightRegex={highlightRegex}
-          filterRegex={filterRegex}
+          highlightRegExp={highlightRegExp}
+          filterRegExp={filterRegExp}
         />
       </LogViewerContainer>
     );

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -1,85 +1,20 @@
 import React from 'react';
 import {
-  LogViewContainer,
-  CloseFileButton,
-  Log,
-  LogLine
+  LogViewerContainer,
+  CloseFileButton
 } from '../styledComponents/LogViewerStyledComponents';
+import LogViewerList from './LogViewerList';
 import { connect } from 'react-redux';
 import { closeFile } from './helpers/handleFileHelper';
-import {
-  calculateSize,
-  calculateWrap,
-  maxLength
-} from 'js/view/components/helpers/measureHelper';
-import TextHighlightRegex from './TextHighlightRegex';
-import WindowedList from 'react-list';
-import {
-  filterByRegExp,
-  parseRegExp
-} from 'js/view/components/helpers/regexHelper.js';
+import { parseRegExp } from 'js/view/components/helpers/regexHelper.js';
 
 class LogViewer extends React.Component {
   constructor(props) {
     super(props);
-    this.logRef = React.createRef();
-    this.windowedListRef = React.createRef();
-    this.rulerRef = React.createRef();
     this.state = {
       escapeRegexSequence: '@'
     };
   }
-
-  scrollToBottom = el => {
-    el.scrollAround(this.lastIndex);
-  };
-
-  componentDidUpdate() {
-    if (this.props.tailSwitch) {
-      // this.scrollToBottom(this.logRef.current);
-      this.scrollToBottom(this.windowedListRef.current);
-    }
-  }
-
-  updateSizes() {}
-
-  itemRenderer = (lineWidth, lines, regex) => {
-    return (i, key) => {
-      return (
-        <LogLine
-          key={key}
-          index={i}
-          fixedWidth={lineWidth}
-          wrap={this.props.wrapLineOn ? 'true' : undefined}
-        >
-          {regex && regex.test(lines[i], regex) ? (
-            <TextHighlightRegex
-              text={lines[i]}
-              color={this.props.highlightColor}
-              regex={regex}
-            />
-          ) : (
-            lines[i]
-          )}
-        </LogLine>
-      );
-    };
-  };
-
-  itemSizeGetter = (lines, charSize, clientWidth) => {
-    const sizes = lines.map(line => {
-      return calculateWrap(charSize, line, clientWidth);
-    });
-    return index => {
-      return sizes[index];
-    };
-  };
-
-  constItemSizeGetter = size => {
-    return index => {
-      return size;
-    };
-  };
 
   render() {
     const highlightRegex = parseRegExp(
@@ -91,27 +26,8 @@ class LogViewer extends React.Component {
       this.state.escapeRegexSequence
     );
 
-    const lines = filterByRegExp(this.props.liveLines, filterRegex);
-
-    this.lastIndex = lines.length - 1;
-
-    const charSize = this.rulerRef.current
-      ? calculateSize('a', this.rulerRef.current)
-      : [0, 0];
-
-    const lineWidth =
-      this.logRef.current && this.props.wrapLineOn
-        ? this.logRef.current.clientWidth
-        : maxLength(lines) * charSize[1];
-
-    const itemSizeGetter = this.props.wrapLineOn
-      ? this.itemSizeGetter(lines, charSize, this.logRef.current.clientWidth)
-      : this.constItemSizeGetter(charSize[0]);
-
-    const itemRenderer = this.itemRenderer(lineWidth, lines, highlightRegex);
-
     return (
-      <LogViewContainer>
+      <LogViewerContainer>
         <CloseFileButton
           openFiles={this.props.openFiles}
           onClick={() => {
@@ -121,24 +37,15 @@ class LogViewer extends React.Component {
             );
           }}
         />
-        <Log ref={this.logRef}>
-          <LogLine
-            style={{
-              visibility: 'hidden',
-              minWidth: 0,
-              display: 'inline-block'
-            }}
-            ref={this.rulerRef}
-          />
-          <WindowedList
-            ref={this.windowedListRef}
-            itemRenderer={itemRenderer}
-            itemSizeGetter={itemSizeGetter}
-            length={lines.length}
-            type="variable"
-          />
-        </Log>
-      </LogViewContainer>
+        <LogViewerList
+          highlightColor={this.props.highlightColor}
+          wrapLines={this.props.wrapLineOn}
+          scrollToBottom={this.props.tailSwitch}
+          lines={this.props.liveLines}
+          highlightRegex={highlightRegex}
+          filterRegex={filterRegex}
+        />
+      </LogViewerContainer>
     );
   }
 }

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -9,7 +9,8 @@ import { connect } from 'react-redux';
 import { closeFile } from './helpers/handleFileHelper';
 import {
   calculateSize,
-  calculateWrap
+  calculateWrap,
+  maxLength
 } from 'js/view/components/helpers/measureHelper';
 import TextHighlightRegex from './TextHighlightRegex';
 import WindowedList from 'react-list';
@@ -39,6 +40,8 @@ class LogViewer extends React.Component {
       this.scrollToBottom(this.windowedListRef.current);
     }
   }
+
+  updateSizes() {}
 
   itemRenderer = (lineWidth, lines, regex) => {
     return (i, key) => {
@@ -82,31 +85,26 @@ class LogViewer extends React.Component {
     const lines = filterByRegExp(this.props.liveLines, filterRegex);
 
     this.lastIndex = lines.length - 1;
+
     let charSize = [0, 0];
+
     if (this.rulerRef.current) {
       charSize = calculateSize('a', this.rulerRef.current);
     }
-    let lineWidth = 0;
-    let itemSizeGetter;
+
+    let lineWidth = this.logRef.current
+      ? this.logRef.current.clientWidth
+      : maxLength(lines) * charSize[0];
+
+    let itemSizeGetter = () => {
+      return charSize[0];
+    };
+
     if (this.props.wrapLineOn) {
       const sizes = lines.map(line => {
         return calculateWrap(charSize, line, this.logRef.current.clientWidth);
       });
       itemSizeGetter = this.itemSizeGetter(sizes);
-    } else {
-      itemSizeGetter = () => {
-        return charSize[0];
-      };
-    }
-
-    if (this.props.wrapLineOn && this.rulerRef.current) {
-      lineWidth = this.logRef.current.clientWidth;
-    } else if (this.rulerRef.current) {
-      let maxStringLength = lines.reduce((max, next) => {
-        return max > next.length ? max : next.length;
-      }, 0);
-
-      lineWidth = maxStringLength * charSize[1];
     }
 
     const itemRenderer = this.itemRenderer(lineWidth, lines, highlightRegex);

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -66,9 +66,18 @@ class LogViewer extends React.Component {
     };
   };
 
-  itemSizeGetter = sizes => {
+  itemSizeGetter = (lines, charSize, clientWidth) => {
+    const sizes = lines.map(line => {
+      return calculateWrap(charSize, line, clientWidth);
+    });
     return index => {
       return sizes[index];
+    };
+  };
+
+  constItemSizeGetter = size => {
+    return index => {
+      return size;
     };
   };
 
@@ -86,26 +95,18 @@ class LogViewer extends React.Component {
 
     this.lastIndex = lines.length - 1;
 
-    let charSize = [0, 0];
+    const charSize = this.rulerRef.current
+      ? calculateSize('a', this.rulerRef.current)
+      : [0, 0];
 
-    if (this.rulerRef.current) {
-      charSize = calculateSize('a', this.rulerRef.current);
-    }
+    const lineWidth =
+      this.logRef.current && this.props.wrapLineOn
+        ? this.logRef.current.clientWidth
+        : maxLength(lines) * charSize[1];
 
-    let lineWidth = this.logRef.current
-      ? this.logRef.current.clientWidth
-      : maxLength(lines) * charSize[0];
-
-    let itemSizeGetter = () => {
-      return charSize[0];
-    };
-
-    if (this.props.wrapLineOn) {
-      const sizes = lines.map(line => {
-        return calculateWrap(charSize, line, this.logRef.current.clientWidth);
-      });
-      itemSizeGetter = this.itemSizeGetter(sizes);
-    }
+    const itemSizeGetter = this.props.wrapLineOn
+      ? this.itemSizeGetter(lines, charSize, this.logRef.current.clientWidth)
+      : this.constItemSizeGetter(charSize[0]);
 
     const itemRenderer = this.itemRenderer(lineWidth, lines, highlightRegex);
 

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -50,7 +50,10 @@ class LogViewerList extends React.Component {
     const filterArgs = [nextProps.filterRegExp];
     const sizeArgs = [charSize, clientWidth];
 
-    if (this.props.filterRegExp !== nextProps.filterRegExp) {
+    if (
+      (this.props.filterRegExp || {}).source !==
+      (nextProps.filterRegExp || {}).source
+    ) {
       this.refreshCaches(lines, filterArgs, sizeArgs);
     } else {
       this.updateCaches(lines, filterArgs, sizeArgs);

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -88,9 +88,12 @@ class LogViewerList extends React.Component {
   };
 
   updateCaches = (lines, filterArgs, sizeArgs) => {
-    this.state.cachedLines.update(lines, filterArgs);
-    this.state.cachedLineHeights.update(this.state.cachedLines.get(), sizeArgs);
-    this.state.cachedLongestLine.update(this.state.cachedLines.get());
+    this.state.cachedLines.diffAppend(lines, filterArgs);
+    this.state.cachedLineHeights.diffAppend(
+      this.state.cachedLines.get(),
+      sizeArgs
+    );
+    this.state.cachedLongestLine.diffReduce(this.state.cachedLines.get());
   };
 
   //The onResize function is debounced as the resize event occurs all the time while resizing the window
@@ -102,7 +105,7 @@ class LogViewerList extends React.Component {
     const cachedLineHeights = this.state.cachedLineHeights;
 
     cachedLineHeights.reset();
-    cachedLineHeights.update(cachedLines.get(), { charSize, clientWidth });
+    cachedLineHeights.diffAppend(cachedLines.get(), { charSize, clientWidth });
 
     this.setState({
       cachedCharSize: charSize,
@@ -117,10 +120,10 @@ class LogViewerList extends React.Component {
 
     cachedLines.reset();
     cachedLineHeights.reset();
-    cachedLines.update(lines, filterArgs);
-    cachedLineHeights.update(cachedLines.get(), sizeArgs);
+    cachedLines.diffAppend(lines, filterArgs);
+    cachedLineHeights.diffAppend(cachedLines.get(), sizeArgs);
     cachedLongestLine.reset();
-    cachedLongestLine.update(cachedLines.get());
+    cachedLongestLine.diffReduce(cachedLines.get());
   };
 
   wrapItemSizeGetter = sizes => {

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import {
+  LogViewerListContainer,
+  LogLine
+} from '../styledComponents/LogViewerListStyledComponents';
+import {
+  calculateSize,
+  calculateWrap,
+  maxLength
+} from 'js/view/components/helpers/measureHelper';
+import TextHighlightRegex from './TextHighlightRegex';
+import WindowedList from 'react-list';
+import { filterByRegExp } from 'js/view/components/helpers/regexHelper.js';
+
+class LogViewer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.logRef = React.createRef();
+    this.windowedListRef = React.createRef();
+    this.rulerRef = React.createRef();
+  }
+
+  scrollToBottom = el => {
+    el.scrollAround(this.lastIndex);
+  };
+
+  componentDidUpdate() {
+    if (this.props.scrollToBottom) {
+      this.scrollToBottom(this.windowedListRef.current);
+    }
+  }
+
+  componentWillUpdate() {}
+
+  itemSizeGetter = (lines, charSize, clientWidth) => {
+    const sizes = lines.map(line => {
+      return calculateWrap(charSize, line, clientWidth);
+    });
+    return index => {
+      return sizes[index];
+    };
+  };
+
+  constItemSizeGetter = size => {
+    return index => {
+      return size;
+    };
+  };
+
+  render() {
+    const lines = filterByRegExp(this.props.lines, this.props.filterRegex);
+
+    this.lastIndex = lines.length - 1;
+    const highlightRegex = this.props.highlightRegex;
+    const wrapLines = this.props.wrapLines;
+    const highlightColor = this.props.highlightColor;
+    const charSize = this.rulerRef.current
+      ? calculateSize('a', this.rulerRef.current)
+      : [0, 0];
+
+    const lineWidth =
+      this.logRef.current && this.props.wrapLines
+        ? this.logRef.current.clientWidth
+        : maxLength(lines) * charSize[1];
+
+    const itemSizeGetter = this.props.wrapLines
+      ? this.itemSizeGetter(lines, charSize, this.logRef.current.clientWidth)
+      : this.constItemSizeGetter(charSize[0]);
+
+    return (
+      <LogViewerListContainer ref={this.logRef}>
+        <LogLine
+          style={{
+            visibility: 'hidden',
+            minWidth: 0,
+            position: 'absolute',
+            display: 'inline-block'
+          }}
+          ref={this.rulerRef}
+        />
+        <WindowedList
+          ref={this.windowedListRef}
+          itemRenderer={(i, key) => {
+            return (
+              <LogLine
+                key={key}
+                index={i}
+                fixedWidth={lineWidth}
+                fixedHeight={itemSizeGetter(i)}
+                wrap={wrapLines ? 'true' : undefined}
+              >
+                {highlightRegex && highlightRegex.test(lines[i]) ? (
+                  <TextHighlightRegex
+                    text={lines[i]}
+                    color={highlightColor}
+                    regex={highlightRegex}
+                  />
+                ) : (
+                  lines[i]
+                )}
+              </LogLine>
+            );
+          }}
+          itemSizeGetter={itemSizeGetter}
+          length={lines.length}
+          type="variable"
+        />
+      </LogViewerListContainer>
+    );
+  }
+}
+
+export default LogViewer;

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -134,13 +134,11 @@ class LogViewerList extends React.Component {
     cachedLines.diffAppend(lines);
     cachedHeightsByLength.diffReduce(cachedLines.get());
     cachedLongestLine.diffReduce(cachedLines.get());
-    console.log(cachedLines.get());
-    console.log(cachedHeightsByLength.get());
   };
 
   wrapItemSizeGetter = (lines, sizes) => {
     return index => {
-      return lines[index] && sizes[lines[index].length];
+      return index < 0 ? 0 : sizes[lines[index].length];
     };
   };
 
@@ -174,6 +172,7 @@ class LogViewerList extends React.Component {
               <LogLine
                 key={key}
                 index={i}
+                minSize={0}
                 fixedWidth={lineWidth}
                 fixedHeight={itemSizeGetter(i)}
                 wrap={wrapLines ? 'true' : undefined}

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -42,19 +42,6 @@ class LogViewerList extends React.Component {
     this.resizeObserver.observe(this.logRef.current);
   }
 
-  componentWillUnmount() {
-    this.resizeObserver.disconnect();
-  }
-
-  componentDidUpdate() {
-    if (this.props.scrollToBottom) {
-      this.scrollToBottom(
-        this.windowedListRef.current,
-        this.state.cachedLines.get().length - 1
-      );
-    }
-  }
-
   componentWillUpdate(nextProps, nextState) {
     const lines = nextProps.lines;
     const charSize = nextState.cachedCharSize;
@@ -67,6 +54,19 @@ class LogViewerList extends React.Component {
     } else {
       this.updateCaches(lines, filterArgs, sizeArgs);
     }
+  }
+
+  componentDidUpdate() {
+    if (this.props.scrollToBottom) {
+      this.scrollToBottom(
+        this.windowedListRef.current,
+        this.state.cachedLines.get().length - 1
+      );
+    }
+  }
+
+  componentWillUnmount() {
+    this.resizeObserver.disconnect();
   }
 
   scrollToBottom = (el, index) => {

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -5,7 +5,6 @@ import {
 } from '../styledComponents/LogViewerListStyledComponents';
 import {
   calculateSize,
-  calculateWrap,
   calculateWraps,
   maxLengthReducer
 } from 'js/view/components/helpers/measureHelper';
@@ -39,11 +38,12 @@ class LogViewerList extends React.Component {
       cachedCharSize: calculateSize('W', this.rulerRef.current)
     });
 
-    window.addEventListener('resize', this.onResize);
+    this.resizeObserver = new ResizeObserver(this.onResize);
+    this.resizeObserver.observe(this.logRef.current);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.onResize);
+    this.resizeObserver.disconnect();
   }
 
   componentDidUpdate() {

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -6,7 +6,7 @@ import {
 } from '../styledComponents/LogViewerListStyledComponents';
 import {
   calculateSize,
-  calculateWrap,
+  calculateWrappedHeight,
   maxLengthReducer
 } from 'js/view/components/helpers/measureHelper';
 import _ from 'lodash';
@@ -42,7 +42,7 @@ class LogViewerList extends React.Component {
       const key = next.length;
       if (map[key]) return map; // No need to recalculate
 
-      const height = calculateWrap(next, charSize, elementWidth);
+      const height = calculateWrappedHeight(next, charSize, elementWidth);
       const mapCopy = { ...map };
       mapCopy[key] = height;
       return mapCopy;
@@ -51,7 +51,7 @@ class LogViewerList extends React.Component {
 
   filterLinesFunc = regex => {
     return lines => {
-      return regex ? filterByRegExp(lines, regex) : lines;
+      return filterByRegExp(lines, regex);
     };
   };
 

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -5,7 +5,9 @@ import {
 } from '../styledComponents/LogViewerListStyledComponents';
 import {
   calculateSize,
-  calculateWrap
+  calculateWrap,
+  calculateWraps,
+  maxLengthReducer
 } from 'js/view/components/helpers/measureHelper';
 import _ from 'lodash';
 import TextHighlightRegex from './TextHighlightRegex';
@@ -23,27 +25,11 @@ class LogViewerList extends React.Component {
     this.windowedListRef = React.createRef();
     this.rulerRef = React.createRef();
 
-    const filterLines = (lines, regex) => {
-      return regex ? filterByRegExp(lines, regex) : lines;
-    };
-
-    const calculateSizes = (lines, charSize, clientWidth) => {
-      return lines.map(line => {
-        return calculateWrap(line, charSize, clientWidth);
-      });
-    };
-
-    const reduceLongestLine = () => {
-      return (max, next) => {
-        return max > next.length ? max : next.length;
-      };
-    };
-
     this.state = {
       cachedCharSize: [0, 0],
-      cachedLines: new CachedTransformedList(filterLines),
-      cachedLineHeights: new CachedTransformedList(calculateSizes),
-      cachedLongestLine: new CachedReducedValue(reduceLongestLine, 0),
+      cachedLines: new CachedTransformedList(filterByRegExp),
+      cachedLineHeights: new CachedTransformedList(calculateWraps),
+      cachedLongestLine: new CachedReducedValue(maxLengthReducer, 0),
       cachedClientWidth: 0
     };
   }

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -23,11 +23,11 @@ class LogViewerList extends React.Component {
     this.windowedListRef = React.createRef();
     this.rulerRef = React.createRef();
 
-    const filterLines = (lines, { regex }) => {
+    const filterLines = (lines, regex) => {
       return regex ? filterByRegExp(lines, regex) : lines;
     };
 
-    const calculateSizes = (lines, { charSize, clientWidth }) => {
+    const calculateSizes = (lines, charSize, clientWidth) => {
       return lines.map(line => {
         return calculateWrap(line, charSize, clientWidth);
       });
@@ -73,8 +73,8 @@ class LogViewerList extends React.Component {
     const lines = nextProps.lines;
     const charSize = nextState.cachedCharSize;
     const clientWidth = this.logRef.current.clientWidth;
-    const filterArgs = { regex: nextProps.filterRegExp };
-    const sizeArgs = { charSize, clientWidth };
+    const filterArgs = [nextProps.filterRegExp];
+    const sizeArgs = [charSize, clientWidth];
 
     if (this.props.filterRegExp !== nextProps.filterRegExp) {
       this.refreshCaches(lines, filterArgs, sizeArgs);
@@ -88,10 +88,10 @@ class LogViewerList extends React.Component {
   };
 
   updateCaches = (lines, filterArgs, sizeArgs) => {
-    this.state.cachedLines.diffAppend(lines, filterArgs);
+    this.state.cachedLines.diffAppend(lines, ...filterArgs);
     this.state.cachedLineHeights.diffAppend(
       this.state.cachedLines.get(),
-      sizeArgs
+      ...sizeArgs
     );
     this.state.cachedLongestLine.diffReduce(this.state.cachedLines.get());
   };
@@ -105,7 +105,7 @@ class LogViewerList extends React.Component {
     const cachedLineHeights = this.state.cachedLineHeights;
 
     cachedLineHeights.reset();
-    cachedLineHeights.diffAppend(cachedLines.get(), { charSize, clientWidth });
+    cachedLineHeights.diffAppend(cachedLines.get(), charSize, clientWidth);
 
     this.setState({
       cachedCharSize: charSize,
@@ -120,8 +120,8 @@ class LogViewerList extends React.Component {
 
     cachedLines.reset();
     cachedLineHeights.reset();
-    cachedLines.diffAppend(lines, filterArgs);
-    cachedLineHeights.diffAppend(cachedLines.get(), sizeArgs);
+    cachedLines.diffAppend(lines, ...filterArgs);
+    cachedLineHeights.diffAppend(cachedLines.get(), ...sizeArgs);
     cachedLongestLine.reset();
     cachedLongestLine.diffReduce(cachedLines.get());
   };

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import {
   LogViewerListContainer,
-  LogLine
+  LogLine,
+  LogLineRuler
 } from '../styledComponents/LogViewerListStyledComponents';
 import {
   calculateSize,
@@ -140,15 +141,7 @@ class LogViewerList extends React.Component {
 
     return (
       <LogViewerListContainer ref={this.logRef}>
-        <LogLine
-          style={{
-            visibility: 'hidden',
-            minWidth: 0,
-            position: 'absolute',
-            display: 'inline-block'
-          }}
-          ref={this.rulerRef}
-        />
+        <LogLineRuler ref={this.rulerRef} />
         <WindowedList
           ref={this.windowedListRef}
           itemRenderer={(i, key) => {

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -95,7 +95,7 @@ class LogViewerList extends React.Component {
 
     this.setState({
       cachedCharSize: charSize,
-      cachedClientWidth: this.logRef.current.clientWidth
+      cachedClientWidth: clientWidth
     }); //This also re-renders, so if this is removed make sure to re-render
   }, 222);
 

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -39,17 +39,15 @@ class LogViewerList extends React.Component {
   }
 
   componentDidMount() {
-    const cachedCharSize = calculateSize('W', this.rulerRef.current);
-
     this.setState({
-      cachedCharSize: cachedCharSize
+      cachedCharSize: calculateSize('W', this.rulerRef.current)
     });
 
-    window.addEventListener('resize', this.debounceRefreshCachedLineHeights);
+    window.addEventListener('resize', this.onResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.debounceRefreshCachedLineHeights);
+    window.removeEventListener('resize', this.onResize);
   }
 
   componentDidUpdate() {
@@ -84,14 +82,20 @@ class LogViewerList extends React.Component {
     this.state.cachedLineHeights.update(lines, sizeArgs);
   };
 
-  debounceRefreshCachedLineHeights = _.debounce(() => {
-    const charSize = this.state.cachedCharSize;
+  //The onResize function is debounced as the resize event occurs all the time while resizing the window
+  onResize = _.debounce(() => {
+    //The line heights needs to be recalculated on a resize
+    const charSize = calculateSize('W', this.rulerRef.current);
     const clientWidth = this.logRef.current.clientWidth;
     const cachedLines = this.state.cachedLines;
     const cachedLineHeights = this.state.cachedLineHeights;
 
     cachedLineHeights.reset();
     cachedLineHeights.update(cachedLines.get(), { charSize, clientWidth });
+
+    this.setState({
+      cachedCharSize: charSize
+    }); //This also re-renders, so if this is removed make sure to re-render
   }, 222);
 
   refreshCaches = (lines, filterArgs, sizeArgs) => {

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -5,14 +5,16 @@ import {
 } from '../styledComponents/LogViewerListStyledComponents';
 import {
   calculateSize,
-  calculateWrap,
-  maxLength
+  calculateWrap
 } from 'js/view/components/helpers/measureHelper';
 import _ from 'lodash';
 import TextHighlightRegex from './TextHighlightRegex';
 import WindowedList from 'react-list';
 import { filterByRegExp } from 'js/view/components/helpers/regexHelper.js';
-import { CachedTransformedList } from 'js/view/components/helpers/cacheHelper.js';
+import {
+  CachedTransformedList,
+  CachedReducedValue
+} from 'js/view/components/helpers/cacheHelper.js';
 
 class LogViewerList extends React.Component {
   constructor(props) {
@@ -31,10 +33,18 @@ class LogViewerList extends React.Component {
       });
     };
 
+    const reduceLongestLine = () => {
+      return (max, next) => {
+        return max > next.length ? max : next.length;
+      };
+    };
+
     this.state = {
       cachedCharSize: [0, 0],
       cachedLines: new CachedTransformedList(filterLines),
-      cachedLineHeights: new CachedTransformedList(calculateSizes)
+      cachedLineHeights: new CachedTransformedList(calculateSizes),
+      cachedLongestLine: new CachedReducedValue(reduceLongestLine, 0),
+      cachedClientWidth: 0
     };
   }
 
@@ -79,7 +89,8 @@ class LogViewerList extends React.Component {
 
   updateCaches = (lines, filterArgs, sizeArgs) => {
     this.state.cachedLines.update(lines, filterArgs);
-    this.state.cachedLineHeights.update(lines, sizeArgs);
+    this.state.cachedLineHeights.update(this.state.cachedLines.get(), sizeArgs);
+    this.state.cachedLongestLine.update(this.state.cachedLines.get());
   };
 
   //The onResize function is debounced as the resize event occurs all the time while resizing the window
@@ -94,18 +105,22 @@ class LogViewerList extends React.Component {
     cachedLineHeights.update(cachedLines.get(), { charSize, clientWidth });
 
     this.setState({
-      cachedCharSize: charSize
+      cachedCharSize: charSize,
+      cachedClientWidth: this.logRef.current.clientWidth
     }); //This also re-renders, so if this is removed make sure to re-render
   }, 222);
 
   refreshCaches = (lines, filterArgs, sizeArgs) => {
     const cachedLines = this.state.cachedLines;
     const cachedLineHeights = this.state.cachedLineHeights;
+    const cachedLongestLine = this.state.cachedLongestLine;
 
     cachedLines.reset();
     cachedLineHeights.reset();
     cachedLines.update(lines, filterArgs);
     cachedLineHeights.update(cachedLines.get(), sizeArgs);
+    cachedLongestLine.reset();
+    cachedLongestLine.update(cachedLines.get());
   };
 
   wrapItemSizeGetter = sizes => {
@@ -126,10 +141,9 @@ class LogViewerList extends React.Component {
     const highlightColor = this.props.highlightColor;
     const lines = this.state.cachedLines.get();
     const sizes = this.state.cachedLineHeights.get();
-    const lineWidth =
-      this.logRef.current && this.props.wrapLines
-        ? this.logRef.current.clientWidth
-        : maxLength(lines) * this.state.cachedCharSize[1];
+    const lineWidth = this.props.wrapLines
+      ? this.state.cachedClientWidth
+      : this.state.cachedLongestLine.get() * this.state.cachedCharSize[1];
 
     const itemSizeGetter = this.props.wrapLines
       ? this.wrapItemSizeGetter(sizes)

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -1,3 +1,8 @@
+/**
+ * CachedReducedValue is a reducer that caches the latest reduced value and uses that as the start value to reduce further
+ * @param {Function} reducerFunc a reducer function (curr, next) => *
+ * @param {*} startValue the start value for the reduction function
+ */
 export class CachedReducedValue {
   constructor(reducerFunc, startValue) {
     this.startValue = startValue;
@@ -20,6 +25,8 @@ export class CachedReducedValue {
 
   /**
    * Reduces the elements between the baseLength and the baseList's length with the existing value
+   * If baseList is shorter, nothing happens
+   * @param {*[]} baseList
    */
   diffReduce(baseList) {
     if (baseList.length <= this.baseLength) return;
@@ -33,7 +40,7 @@ export class CachedReducedValue {
 
   /**
    * Returns the reduced value
-   * @returns {object}
+   * @returns {*}
    */
   get() {
     return this.value;
@@ -42,8 +49,7 @@ export class CachedReducedValue {
 
 /**
  * CachedTransformedList is a cached list with that is transformed by some function (listFunc)
- * @param {function(object[], object)} listFunc
- * @returns {object}
+ * @param {Function} listFunc of type (object[], ...args) => object[]
  */
 export class CachedTransformedList {
   constructor(listFunc) {
@@ -67,8 +73,9 @@ export class CachedTransformedList {
   /**
    * Transforms and appends the elements between the baseLength and the baseList's length to the internal list
    * Additional arguments are passed to listFunc
-   * @param {object[]} baseList
-   * @param {object} args
+   * If baseList is shorter, nothing happens
+   * @param {*[]} baseList
+   * @param {...*} args
    */
   diffAppend(baseList, ...args) {
     if (baseList.length <= this.baseLength) return;
@@ -82,7 +89,7 @@ export class CachedTransformedList {
 
   /**
    * Returns the transformed list
-   * @returns {object[]}
+   * @returns {*[]}
    */
   get() {
     return this.transformedList;

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -15,15 +15,15 @@ export class CachedReducedValue {
   }
 
   /**
-   * Reduces the current value with all the new values
+   * Reducese the elements between the baseLength and the baseList's length with the existing value
+   * Extra arguments are bundled as an object and passed to the reducerFunc as the second parameter
    */
-  update(baseList, args) {
+  diffReduce(baseList, args) {
     if (baseList.length <= this.baseLength) return;
 
-    this.value = [
-      this.value,
-      ...baseList.slice(Math.max(this.baseLength, 0))
-    ].reduce(this.reducerFunc(args));
+    this.value = [this.value, ...baseList.slice(this.baseLength)].reduce(
+      this.reducerFunc(args)
+    );
 
     this.baseLength = baseList.length;
   }
@@ -62,18 +62,15 @@ export class CachedTransformedList {
   }
 
   /**
-   * Updates the cached list with any new elements from the baseList, with the listFunc applied to the new elements
+   * Transforms and appends the elements between the baseLength and the baseList's length to the internal list
    * Extra arguments are bundled as an object and passed to the listFunc as the second parameter
    * @param {object[]} baseList
    * @param {object} args
    */
-  update(baseList, args) {
+  diffAppend(baseList, args) {
     if (baseList.length <= this.baseLength) return;
 
-    const newItems = this.listFunc(
-      baseList.slice(Math.max(this.baseLength, 0)),
-      args
-    );
+    const newItems = this.listFunc(baseList.slice(this.baseLength), args);
 
     this.transformedList.push(...newItems);
 

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -1,3 +1,42 @@
+export class CachedReducedValue {
+  constructor(reducerFunc, startValue) {
+    this.startValue = startValue;
+    this.value = startValue;
+    this.baseLength = 0;
+    this.reducerFunc = reducerFunc;
+  }
+
+  /**
+   * Resets the cache and sets the value to the starting value
+   */
+  reset() {
+    this.value = this.startValue;
+    this.baseLength = 0;
+  }
+
+  /**
+   * Reduces the current value with all the new values
+   */
+  update(baseList, args) {
+    if (baseList.length <= this.baseLength) return;
+
+    this.value = [
+      this.value,
+      ...baseList.slice(Math.max(this.baseLength, 0))
+    ].reduce(this.reducerFunc(args));
+
+    this.baseLength = baseList.length;
+  }
+
+  /**
+   * Returns the reduced value
+   * @returns {object}
+   */
+  get() {
+    return this.value;
+  }
+}
+
 /**
  * CachedTransformedList is a cached list with that is transformed by some function (listFunc)
  * @param {function(object[], object)} listFunc

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -5,23 +5,23 @@
  */
 export class CachedReducedValue {
   constructor(reducerFunc, startValue) {
-    this.startValue = startValue;
-    this.value = startValue;
-    this.baseLength = 0;
     this.reducerFunc = reducerFunc
       ? reducerFunc
-      : () => {
-          return (_, next) => {
-            return next;
-          };
+      : (_, next) => {
+          return next;
         };
+
+    this.reset(reducerFunc, startValue);
   }
 
   /**
    * Resets the cache and sets the value to the starting value
    */
-  reset() {
+  reset(reducerFunc, startValue) {
+    this.startValue = startValue !== undefined ? startValue : this.startValue;
     this.value = this.startValue;
+    this.reducerFunc =
+      reducerFunc !== undefined ? reducerFunc : this.reducerFunc;
     this.baseLength = 0;
   }
 
@@ -30,12 +30,12 @@ export class CachedReducedValue {
    * If baseList is shorter, nothing happens
    * @param {*[]} baseList
    */
-  diffReduce(baseList, ...args) {
+  diffReduce(baseList) {
     if (baseList.length <= this.baseLength) return;
 
     this.value = baseList
       .slice(this.baseLength)
-      .reduce(this.reducerFunc(...args), this.value);
+      .reduce(this.reducerFunc, this.value);
 
     this.baseLength = baseList.length;
   }
@@ -55,34 +55,34 @@ export class CachedReducedValue {
  */
 export class CachedTransformedList {
   constructor(listFunc) {
-    this.transformedList = [];
-    this.baseLength = 0;
     this.listFunc = listFunc
       ? listFunc
       : x => {
           return x;
         };
+
+    this.reset(listFunc);
   }
 
   /**
    * Clears the list of items
    */
-  reset() {
+  reset(listFunc) {
     this.transformedList = [];
+    this.listFunc = listFunc !== undefined ? listFunc : this.listFunc;
     this.baseLength = 0;
   }
 
   /**
    * Transforms and appends the elements between the baseLength and the baseList's length to the internal list
-   * Additional arguments are passed to listFunc
    * If baseList is shorter, nothing happens
    * @param {*[]} baseList
    * @param {...*} args
    */
-  diffAppend(baseList, ...args) {
+  diffAppend(baseList) {
     if (baseList.length <= this.baseLength) return;
 
-    const newItems = this.listFunc(baseList.slice(this.baseLength), ...args);
+    const newItems = this.listFunc(baseList.slice(this.baseLength));
 
     this.transformedList.push(...newItems);
 

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -1,0 +1,48 @@
+/**
+ * new CachedTransformedList is a cached list with some function (listFunc)
+ * applied to all elements in the list
+ * @param {function(object[], object)} listFunc
+ * @returns {object}
+ */
+export const CachedTransformedList = listFunc => {
+  let transformedList = [];
+  let baseLength = 0;
+
+  /**
+   * Resets the list
+   */
+  const reset = () => {
+    transformedList = [];
+    baseLength = 0;
+  };
+
+  /**
+   * Updates the cached list with any new elements from the baseList, with the listFunc applied to the new elements
+   * Extra arguments are bundled as an object and passed to the listFunc as the second parameter
+   * @param {object[]} baseList
+   * @param {object} args
+   */
+  const update = (baseList, args) => {
+    if (baseList.length <= baseLength) return;
+
+    const newItems = listFunc(baseList.slice(Math.max(baseLength, 0)), args);
+
+    transformedList.push(...newItems);
+
+    baseLength = baseList.length;
+  };
+
+  /**
+   * Returns the transformed list
+   * @returns {object[]}
+   */
+  const get = () => {
+    return transformedList;
+  };
+
+  return {
+    update,
+    get,
+    reset
+  };
+};

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -10,8 +10,10 @@ export class CachedReducedValue {
     this.baseLength = 0;
     this.reducerFunc = reducerFunc
       ? reducerFunc
-      : (_, next) => {
-          return next;
+      : () => {
+          return (_, next) => {
+            return next;
+          };
         };
   }
 
@@ -28,12 +30,12 @@ export class CachedReducedValue {
    * If baseList is shorter, nothing happens
    * @param {*[]} baseList
    */
-  diffReduce(baseList) {
+  diffReduce(baseList, ...args) {
     if (baseList.length <= this.baseLength) return;
 
     this.value = baseList
       .slice(this.baseLength)
-      .reduce(this.reducerFunc, this.value);
+      .reduce(this.reducerFunc(...args), this.value);
 
     this.baseLength = baseList.length;
   }

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -3,7 +3,11 @@ export class CachedReducedValue {
     this.startValue = startValue;
     this.value = startValue;
     this.baseLength = 0;
-    this.reducerFunc = reducerFunc;
+    this.reducerFunc = reducerFunc
+      ? reducerFunc
+      : (_, next) => {
+          return next;
+        };
   }
 
   /**
@@ -16,14 +20,13 @@ export class CachedReducedValue {
 
   /**
    * Reduces the elements between the baseLength and the baseList's length with the existing value
-   * Additional arguments are passed to reducerFunc
    */
-  diffReduce(baseList, ...args) {
+  diffReduce(baseList) {
     if (baseList.length <= this.baseLength) return;
 
-    this.value = [this.value, ...baseList.slice(this.baseLength)].reduce(
-      this.reducerFunc(...args)
-    );
+    this.value = baseList
+      .slice(this.baseLength)
+      .reduce(this.reducerFunc, this.value);
 
     this.baseLength = baseList.length;
   }

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -1,20 +1,26 @@
 /**
- * new CachedTransformedList is a cached list with some function (listFunc)
- * applied to all elements in the list
+ * CachedTransformedList is a cached list with that is transformed by some function (listFunc)
  * @param {function(object[], object)} listFunc
  * @returns {object}
  */
-export const CachedTransformedList = listFunc => {
-  let transformedList = [];
-  let baseLength = 0;
+export class CachedTransformedList {
+  constructor(listFunc) {
+    this.transformedList = [];
+    this.baseLength = 0;
+    this.listFunc = listFunc
+      ? listFunc
+      : x => {
+          return x;
+        };
+  }
 
   /**
-   * Resets the list
+   * Clears the list of items
    */
-  const reset = () => {
-    transformedList = [];
-    baseLength = 0;
-  };
+  reset() {
+    this.transformedList = [];
+    this.baseLength = 0;
+  }
 
   /**
    * Updates the cached list with any new elements from the baseList, with the listFunc applied to the new elements
@@ -22,27 +28,24 @@ export const CachedTransformedList = listFunc => {
    * @param {object[]} baseList
    * @param {object} args
    */
-  const update = (baseList, args) => {
-    if (baseList.length <= baseLength) return;
+  update(baseList, args) {
+    if (baseList.length <= this.baseLength) return;
 
-    const newItems = listFunc(baseList.slice(Math.max(baseLength, 0)), args);
+    const newItems = this.listFunc(
+      baseList.slice(Math.max(this.baseLength, 0)),
+      args
+    );
 
-    transformedList.push(...newItems);
+    this.transformedList.push(...newItems);
 
-    baseLength = baseList.length;
-  };
+    this.baseLength = baseList.length;
+  }
 
   /**
    * Returns the transformed list
    * @returns {object[]}
    */
-  const get = () => {
-    return transformedList;
-  };
-
-  return {
-    update,
-    get,
-    reset
-  };
-};
+  get() {
+    return this.transformedList;
+  }
+}

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -15,14 +15,14 @@ export class CachedReducedValue {
   }
 
   /**
-   * Reducese the elements between the baseLength and the baseList's length with the existing value
-   * Extra arguments are bundled as an object and passed to the reducerFunc as the second parameter
+   * Reduces the elements between the baseLength and the baseList's length with the existing value
+   * Additional arguments are passed to reducerFunc
    */
-  diffReduce(baseList, args) {
+  diffReduce(baseList, ...args) {
     if (baseList.length <= this.baseLength) return;
 
     this.value = [this.value, ...baseList.slice(this.baseLength)].reduce(
-      this.reducerFunc(args)
+      this.reducerFunc(...args)
     );
 
     this.baseLength = baseList.length;
@@ -63,14 +63,14 @@ export class CachedTransformedList {
 
   /**
    * Transforms and appends the elements between the baseLength and the baseList's length to the internal list
-   * Extra arguments are bundled as an object and passed to the listFunc as the second parameter
+   * Additional arguments are passed to listFunc
    * @param {object[]} baseList
    * @param {object} args
    */
-  diffAppend(baseList, args) {
+  diffAppend(baseList, ...args) {
     if (baseList.length <= this.baseLength) return;
 
-    const newItems = this.listFunc(baseList.slice(this.baseLength), args);
+    const newItems = this.listFunc(baseList.slice(this.baseLength), ...args);
 
     this.transformedList.push(...newItems);
 

--- a/src/js/view/components/helpers/cacheHelper.js
+++ b/src/js/view/components/helpers/cacheHelper.js
@@ -3,75 +3,75 @@
  * @param {Function} reducerFunc a reducer function (curr, next) => *
  * @param {*} startValue the start value for the reduction function
  */
-export class CachedReducedValue {
-  constructor(reducerFunc, startValue) {
-    this.reducerFunc = reducerFunc
-      ? reducerFunc
-      : (_, next) => {
-          return next;
-        };
-
-    this.reset(reducerFunc, startValue);
-  }
+export const CachedReducedValue = (reducerFunc, startValue) => {
+  let _reducerFunc = (_, next) => {
+    return next;
+  };
+  let _startValue;
+  let _diffLength;
+  let _value;
 
   /**
    * Resets the cache and sets the value to the starting value
    */
-  reset(reducerFunc, startValue) {
-    this.startValue = startValue !== undefined ? startValue : this.startValue;
-    this.value = this.startValue;
-    this.reducerFunc =
-      reducerFunc !== undefined ? reducerFunc : this.reducerFunc;
-    this.baseLength = 0;
-  }
+  const reset = (reducerFunc, startValue) => {
+    _startValue = startValue !== undefined ? startValue : _startValue;
+    _value = _startValue;
+    _reducerFunc = reducerFunc !== undefined ? reducerFunc : _reducerFunc;
+    _diffLength = 0;
+  };
+
+  reset(reducerFunc, startValue);
 
   /**
    * Reduces the elements between the baseLength and the baseList's length with the existing value
    * If baseList is shorter, nothing happens
    * @param {*[]} baseList
    */
-  diffReduce(baseList) {
-    if (baseList.length <= this.baseLength) return;
+  const diffReduce = diffList => {
+    if (diffList.length <= _diffLength) return;
 
-    this.value = baseList
-      .slice(this.baseLength)
-      .reduce(this.reducerFunc, this.value);
+    _value = diffList.slice(_diffLength).reduce(_reducerFunc, _value);
 
-    this.baseLength = baseList.length;
-  }
+    _diffLength = diffList.length;
+  };
 
   /**
    * Returns the reduced value
    * @returns {*}
    */
-  get() {
-    return this.value;
-  }
-}
+  const get = () => {
+    return _value;
+  };
+
+  return {
+    get,
+    diffReduce,
+    reset
+  };
+};
 
 /**
  * CachedTransformedList is a cached list with that is transformed by some function (listFunc)
  * @param {Function} listFunc of type (object[], ...args) => object[]
  */
-export class CachedTransformedList {
-  constructor(listFunc) {
-    this.listFunc = listFunc
-      ? listFunc
-      : x => {
-          return x;
-        };
-
-    this.reset(listFunc);
-  }
+export const CachedTransformedList = listFunc => {
+  let _listFunc = x => {
+    return x;
+  };
+  let _transformedList;
+  let _diffLength;
 
   /**
    * Clears the list of items
    */
-  reset(listFunc) {
-    this.transformedList = [];
-    this.listFunc = listFunc !== undefined ? listFunc : this.listFunc;
-    this.baseLength = 0;
-  }
+  const reset = listFunc => {
+    _transformedList = [];
+    _listFunc = listFunc !== undefined ? listFunc : _listFunc;
+    _diffLength = 0;
+  };
+
+  reset(listFunc);
 
   /**
    * Transforms and appends the elements between the baseLength and the baseList's length to the internal list
@@ -79,21 +79,27 @@ export class CachedTransformedList {
    * @param {*[]} baseList
    * @param {...*} args
    */
-  diffAppend(baseList) {
-    if (baseList.length <= this.baseLength) return;
+  const diffAppend = diffList => {
+    if (diffList.length <= _diffLength) return;
 
-    const newItems = this.listFunc(baseList.slice(this.baseLength));
+    const newItems = _listFunc(diffList.slice(_diffLength));
 
-    this.transformedList.push(...newItems);
+    _transformedList.push(...newItems);
 
-    this.baseLength = baseList.length;
-  }
+    _diffLength = diffList.length;
+  };
 
   /**
    * Returns the transformed list
    * @returns {*[]}
    */
-  get() {
-    return this.transformedList;
-  }
-}
+  const get = () => {
+    return _transformedList;
+  };
+
+  return {
+    get,
+    diffAppend,
+    reset
+  };
+};

--- a/src/js/view/components/helpers/cacheHelper.test.js
+++ b/src/js/view/components/helpers/cacheHelper.test.js
@@ -1,8 +1,10 @@
 import { CachedTransformedList, CachedReducedValue } from './cacheHelper';
 
 describe('CachedReducedValue', () => {
-  const maxFunc = (max, next) => {
-    return next > max ? next : max;
+  const maxFunc = () => {
+    return (max, next) => {
+      return next > max ? next : max;
+    };
   };
 
   describe('get', () => {
@@ -43,6 +45,23 @@ describe('CachedReducedValue', () => {
 
       value.diffReduce(array);
       value.diffReduce(array2);
+
+      expect(value.get()).toEqual(expectedResult);
+    });
+
+    it('should pass arguments to function', () => {
+      const f = (...args) => {
+        return (prev, _next) => {
+          return [...prev, ...args];
+        };
+      };
+      const value = new CachedReducedValue(f, []);
+      const array = [0, 1, 2];
+      const expectedResult = [4, 5, 6, 8, 9, 6, 7, 5];
+
+      value.diffReduce(array.slice(0, 1), 4, 5, 6);
+      value.diffReduce(array.slice(0, 2), 8, 9);
+      value.diffReduce(array.slice(0, 3), 6, 7, 5);
 
       expect(value.get()).toEqual(expectedResult);
     });
@@ -180,6 +199,21 @@ describe('CachedTransformedList', () => {
 
       list.diffAppend(array);
       list.diffAppend(array2);
+
+      expect(list.get()).toEqual(expectedResult);
+    });
+
+    it('should pass arguments to function', () => {
+      const f = (_items, ...args) => {
+        return args;
+      };
+      const list = new CachedTransformedList(f);
+      const array = [0, 1, 2];
+      const expectedResult = [4, 5, 6, 8, 9, 6, 7, 5];
+
+      list.diffAppend(array.slice(0, 1), 4, 5, 6);
+      list.diffAppend(array.slice(0, 2), 8, 9);
+      list.diffAppend(array.slice(0, 3), 6, 7, 5);
 
       expect(list.get()).toEqual(expectedResult);
     });

--- a/src/js/view/components/helpers/cacheHelper.test.js
+++ b/src/js/view/components/helpers/cacheHelper.test.js
@@ -14,7 +14,7 @@ describe('CachedTransformedList', () => {
       const array = ['a', 'b', 'c'];
       const expectedResult = ['a', 'b', 'c'];
 
-      list.update(array);
+      list.diffAppend(array);
 
       expect(list.get()).toEqual(expectedResult);
     });
@@ -27,20 +27,20 @@ describe('CachedTransformedList', () => {
       const array = ['a', 'b', 'c'];
       const expectedResult = ['b', 'c'];
 
-      list.update(array);
+      list.diffAppend(array);
 
       expect(list.get()).toEqual(expectedResult);
     });
   });
 
-  describe('update', () => {
+  describe('diffAppend', () => {
     it('should append new elements', () => {
       const list = new CachedTransformedList();
-      list.update(['a']);
+      list.diffAppend(['a']);
       expect(list.get()).toEqual(['a']);
-      list.update(['a', 'b']);
+      list.diffAppend(['a', 'b']);
       expect(list.get()).toEqual(['a', 'b']);
-      list.update(['a', 'b', 'c']);
+      list.diffAppend(['a', 'b', 'c']);
       expect(list.get()).toEqual(['a', 'b', 'c']);
     });
     it('should apply function', () => {
@@ -55,7 +55,7 @@ describe('CachedTransformedList', () => {
       const array = [false, true, false, false, true];
       const expectedResult = f(array); // [true, true]
 
-      list.update(array);
+      list.diffAppend(array);
       expect(list.get()).toEqual(expectedResult);
     });
 
@@ -71,7 +71,7 @@ describe('CachedTransformedList', () => {
       const expectedResult = [2, 3, 4, 5, 6, 5, 4, 1000];
 
       array.forEach((_, i) => {
-        list.update(array.slice(0, i + 1));
+        list.diffAppend(array.slice(0, i + 1));
       });
 
       expect(list.get()).toEqual(expectedResult);
@@ -89,7 +89,7 @@ describe('CachedTransformedList', () => {
       const array = ['a', 'b', 'c', 'a', 'b', 'a', 'c', 'c', 'b'];
 
       array.forEach((_, i) => {
-        list.update(array.slice(0, i + 1));
+        list.diffAppend(array.slice(0, i + 1));
       });
 
       const expectedResult = ['a', 'b', 'a', 'b', 'a', 'b'];
@@ -103,8 +103,8 @@ describe('CachedTransformedList', () => {
       const array2 = ['q', 'h', 'c'];
       const expectedResult = ['a', 'b', 'c'];
 
-      list.update(array);
-      list.update(array2);
+      list.diffAppend(array);
+      list.diffAppend(array2);
 
       expect(list.get()).toEqual(expectedResult);
     });
@@ -115,7 +115,7 @@ describe('CachedTransformedList', () => {
       const list = new CachedTransformedList();
       const array = ['a', 'b'];
 
-      list.update(array);
+      list.diffAppend(array);
       list.reset();
 
       expect(list.get()).toEqual([]);
@@ -126,9 +126,9 @@ describe('CachedTransformedList', () => {
       const array = ['a', 'b', 'c'];
       const array2 = ['q', 'h'];
 
-      list.update(array);
+      list.diffAppend(array);
       list.reset();
-      list.update(array2);
+      list.diffAppend(array2);
 
       expect(list.get()).toEqual(array2);
     });

--- a/src/js/view/components/helpers/cacheHelper.test.js
+++ b/src/js/view/components/helpers/cacheHelper.test.js
@@ -1,4 +1,79 @@
-import { CachedTransformedList } from './cacheHelper';
+import { CachedTransformedList, CachedReducedValue } from './cacheHelper';
+
+describe('CachedReducedValue', () => {
+  const maxFunc = (max, next) => {
+    return next > max ? next : max;
+  };
+
+  describe('get', () => {
+    it('should return start value', () => {
+      const value = new CachedReducedValue(null, 45);
+      const expectedResult = 45;
+
+      expect(value.get()).toEqual(expectedResult);
+    });
+
+    it('should return latest value', () => {
+      const value = new CachedReducedValue();
+      const array = ['a', 'b', 'c'];
+      const expectedResult = 'c';
+
+      value.diffReduce(array);
+
+      expect(value.get()).toEqual(expectedResult);
+    });
+  });
+
+  describe('diffReduce', () => {
+    it('should return max value', () => {
+      const value = new CachedReducedValue(maxFunc, 0);
+      const array = [1, 2, 4, 65, 8, 2, 2, 6];
+      const expectedResult = 65;
+
+      value.diffReduce(array);
+
+      expect(value.get()).toEqual(expectedResult);
+    });
+
+    it('should not reduce old elements', () => {
+      const value = new CachedReducedValue(maxFunc, 0);
+      const array = [1, 2];
+      const array2 = [65, 100, 1];
+      const expectedResult = 2;
+
+      value.diffReduce(array);
+      value.diffReduce(array2);
+
+      expect(value.get()).toEqual(expectedResult);
+    });
+  });
+
+  describe('reset', () => {
+    it('should return start value', () => {
+      const value = new CachedReducedValue(maxFunc, 1);
+      const array = [2, 3, 4, 5];
+      const expectedResult = 1;
+
+      value.diffReduce(array);
+      value.reset();
+
+      expect(value.get()).toEqual(expectedResult);
+    });
+
+    it('should be possible to add reduce new values after resetting value', () => {
+      const value = new CachedReducedValue();
+      const array = ['a', 'b', 'c'];
+      const array2 = ['q', 'h'];
+      const expectedResult = 'h';
+
+      value.diffReduce(array);
+      value.reset();
+      value.diffReduce(array2);
+
+      expect(value.get()).toEqual(expectedResult);
+    });
+  });
+});
 
 describe('CachedTransformedList', () => {
   describe('get', () => {

--- a/src/js/view/components/helpers/cacheHelper.test.js
+++ b/src/js/view/components/helpers/cacheHelper.test.js
@@ -7,14 +7,14 @@ describe('CachedReducedValue', () => {
 
   describe('get', () => {
     it('should return start value', () => {
-      const value = new CachedReducedValue(null, 45);
+      const value = CachedReducedValue(undefined, 45);
       const expectedResult = 45;
 
       expect(value.get()).toEqual(expectedResult);
     });
 
     it('should return latest value', () => {
-      const value = new CachedReducedValue();
+      const value = CachedReducedValue();
       const array = ['a', 'b', 'c'];
       const expectedResult = 'c';
 
@@ -26,7 +26,7 @@ describe('CachedReducedValue', () => {
 
   describe('diffReduce', () => {
     it('should return max value', () => {
-      const value = new CachedReducedValue(maxFunc, 0);
+      const value = CachedReducedValue(maxFunc, 0);
       const array = [1, 2, 4, 65, 8, 2, 2, 6];
       const expectedResult = 65;
 
@@ -36,7 +36,7 @@ describe('CachedReducedValue', () => {
     });
 
     it('should not reduce old elements', () => {
-      const value = new CachedReducedValue(maxFunc, 0);
+      const value = CachedReducedValue(maxFunc, 0);
       const array = [1, 2];
       const array2 = [65, 100, 1];
       const expectedResult = 2;
@@ -50,7 +50,7 @@ describe('CachedReducedValue', () => {
 
   describe('reset', () => {
     it('should return start value', () => {
-      const value = new CachedReducedValue(maxFunc, 1);
+      const value = CachedReducedValue(maxFunc, 1);
       const array = [2, 3, 4, 5];
       const expectedResult = 1;
 
@@ -61,7 +61,7 @@ describe('CachedReducedValue', () => {
     });
 
     it('should be possible to add reduce new values after resetting value', () => {
-      const value = new CachedReducedValue();
+      const value = CachedReducedValue();
       const array = ['a', 'b', 'c'];
       const array2 = ['q', 'h'];
       const expectedResult = 'h';
@@ -78,14 +78,14 @@ describe('CachedReducedValue', () => {
 describe('CachedTransformedList', () => {
   describe('get', () => {
     it('should return empty list', () => {
-      const list = new CachedTransformedList();
+      const list = CachedTransformedList();
       const expectedResult = [];
 
       expect(list.get()).toEqual(expectedResult);
     });
 
     it('should return same list', () => {
-      const list = new CachedTransformedList();
+      const list = CachedTransformedList();
       const array = ['a', 'b', 'c'];
       const expectedResult = ['a', 'b', 'c'];
 
@@ -95,7 +95,7 @@ describe('CachedTransformedList', () => {
     });
 
     it('should return subset of list', () => {
-      const list = new CachedTransformedList(x => {
+      const list = CachedTransformedList(x => {
         return x.slice(1);
       });
 
@@ -110,7 +110,7 @@ describe('CachedTransformedList', () => {
 
   describe('diffAppend', () => {
     it('should append new elements', () => {
-      const list = new CachedTransformedList();
+      const list = CachedTransformedList();
       list.diffAppend(['a']);
       expect(list.get()).toEqual(['a']);
       list.diffAppend(['a', 'b']);
@@ -125,7 +125,7 @@ describe('CachedTransformedList', () => {
         });
       };
 
-      const list = new CachedTransformedList(f);
+      const list = CachedTransformedList(f);
 
       const array = [false, true, false, false, true];
       const expectedResult = f(array); // [true, true]
@@ -141,7 +141,7 @@ describe('CachedTransformedList', () => {
         });
       };
 
-      const list = new CachedTransformedList(f);
+      const list = CachedTransformedList(f);
       const array = [1, 2, 3, 4, 5, 4, 3, 999];
       const expectedResult = [2, 3, 4, 5, 6, 5, 4, 1000];
 
@@ -159,7 +159,7 @@ describe('CachedTransformedList', () => {
         });
       };
 
-      const list = new CachedTransformedList(f);
+      const list = CachedTransformedList(f);
 
       const array = ['a', 'b', 'c', 'a', 'b', 'a', 'c', 'c', 'b'];
 
@@ -173,7 +173,7 @@ describe('CachedTransformedList', () => {
     });
 
     it('should not update old elements', () => {
-      const list = new CachedTransformedList();
+      const list = CachedTransformedList();
       const array = ['a', 'b'];
       const array2 = ['q', 'h', 'c'];
       const expectedResult = ['a', 'b', 'c'];
@@ -187,7 +187,7 @@ describe('CachedTransformedList', () => {
 
   describe('reset', () => {
     it('should return empty list', () => {
-      const list = new CachedTransformedList();
+      const list = CachedTransformedList();
       const array = ['a', 'b'];
 
       list.diffAppend(array);
@@ -197,7 +197,7 @@ describe('CachedTransformedList', () => {
     });
 
     it('should be possible to add new elements after resetting list', () => {
-      const list = new CachedTransformedList();
+      const list = CachedTransformedList();
       const array = ['a', 'b', 'c'];
       const array2 = ['q', 'h'];
 

--- a/src/js/view/components/helpers/cacheHelper.test.js
+++ b/src/js/view/components/helpers/cacheHelper.test.js
@@ -1,0 +1,136 @@
+import { CachedTransformedList } from './cacheHelper';
+
+describe('CachedTransformedList', () => {
+  describe('get', () => {
+    it('should return empty list', () => {
+      const list = new CachedTransformedList();
+      const expectedResult = [];
+
+      expect(list.get()).toEqual(expectedResult);
+    });
+
+    it('should return same list', () => {
+      const list = new CachedTransformedList();
+      const array = ['a', 'b', 'c'];
+      const expectedResult = ['a', 'b', 'c'];
+
+      list.update(array);
+
+      expect(list.get()).toEqual(expectedResult);
+    });
+
+    it('should return subset of list', () => {
+      const list = new CachedTransformedList(x => {
+        return x.slice(1);
+      });
+
+      const array = ['a', 'b', 'c'];
+      const expectedResult = ['b', 'c'];
+
+      list.update(array);
+
+      expect(list.get()).toEqual(expectedResult);
+    });
+  });
+
+  describe('update', () => {
+    it('should append new elements', () => {
+      const list = new CachedTransformedList();
+      list.update(['a']);
+      expect(list.get()).toEqual(['a']);
+      list.update(['a', 'b']);
+      expect(list.get()).toEqual(['a', 'b']);
+      list.update(['a', 'b', 'c']);
+      expect(list.get()).toEqual(['a', 'b', 'c']);
+    });
+    it('should apply function', () => {
+      const f = x => {
+        return x.filter(y => {
+          return y;
+        });
+      };
+
+      const list = new CachedTransformedList(f);
+
+      const array = [false, true, false, false, true];
+      const expectedResult = f(array); // [true, true]
+
+      list.update(array);
+      expect(list.get()).toEqual(expectedResult);
+    });
+
+    it('should apply function to new elements', () => {
+      const f = x => {
+        return x.map(y => {
+          return y + 1;
+        });
+      };
+
+      const list = new CachedTransformedList(f);
+      const array = [1, 2, 3, 4, 5, 4, 3, 999];
+      const expectedResult = [2, 3, 4, 5, 6, 5, 4, 1000];
+
+      array.forEach((_, i) => {
+        list.update(array.slice(0, i + 1));
+      });
+
+      expect(list.get()).toEqual(expectedResult);
+    });
+
+    it('should append to smaller array', () => {
+      const f = x => {
+        return x.filter(y => {
+          return y.match(/a|b/);
+        });
+      };
+
+      const list = new CachedTransformedList(f);
+
+      const array = ['a', 'b', 'c', 'a', 'b', 'a', 'c', 'c', 'b'];
+
+      array.forEach((_, i) => {
+        list.update(array.slice(0, i + 1));
+      });
+
+      const expectedResult = ['a', 'b', 'a', 'b', 'a', 'b'];
+
+      expect(list.get()).toEqual(expectedResult);
+    });
+
+    it('should not update old elements', () => {
+      const list = new CachedTransformedList();
+      const array = ['a', 'b'];
+      const array2 = ['q', 'h', 'c'];
+      const expectedResult = ['a', 'b', 'c'];
+
+      list.update(array);
+      list.update(array2);
+
+      expect(list.get()).toEqual(expectedResult);
+    });
+  });
+
+  describe('reset', () => {
+    it('should return empty list', () => {
+      const list = new CachedTransformedList();
+      const array = ['a', 'b'];
+
+      list.update(array);
+      list.reset();
+
+      expect(list.get()).toEqual([]);
+    });
+
+    it('should be possible to add new elements after resetting list', () => {
+      const list = new CachedTransformedList();
+      const array = ['a', 'b', 'c'];
+      const array2 = ['q', 'h'];
+
+      list.update(array);
+      list.reset();
+      list.update(array2);
+
+      expect(list.get()).toEqual(array2);
+    });
+  });
+});

--- a/src/js/view/components/helpers/cacheHelper.test.js
+++ b/src/js/view/components/helpers/cacheHelper.test.js
@@ -1,10 +1,8 @@
 import { CachedTransformedList, CachedReducedValue } from './cacheHelper';
 
 describe('CachedReducedValue', () => {
-  const maxFunc = () => {
-    return (max, next) => {
-      return next > max ? next : max;
-    };
+  const maxFunc = (max, next) => {
+    return next > max ? next : max;
   };
 
   describe('get', () => {
@@ -45,23 +43,6 @@ describe('CachedReducedValue', () => {
 
       value.diffReduce(array);
       value.diffReduce(array2);
-
-      expect(value.get()).toEqual(expectedResult);
-    });
-
-    it('should pass arguments to function', () => {
-      const f = (...args) => {
-        return (prev, _next) => {
-          return [...prev, ...args];
-        };
-      };
-      const value = new CachedReducedValue(f, []);
-      const array = [0, 1, 2];
-      const expectedResult = [4, 5, 6, 8, 9, 6, 7, 5];
-
-      value.diffReduce(array.slice(0, 1), 4, 5, 6);
-      value.diffReduce(array.slice(0, 2), 8, 9);
-      value.diffReduce(array.slice(0, 3), 6, 7, 5);
 
       expect(value.get()).toEqual(expectedResult);
     });
@@ -199,21 +180,6 @@ describe('CachedTransformedList', () => {
 
       list.diffAppend(array);
       list.diffAppend(array2);
-
-      expect(list.get()).toEqual(expectedResult);
-    });
-
-    it('should pass arguments to function', () => {
-      const f = (_items, ...args) => {
-        return args;
-      };
-      const list = new CachedTransformedList(f);
-      const array = [0, 1, 2];
-      const expectedResult = [4, 5, 6, 8, 9, 6, 7, 5];
-
-      list.diffAppend(array.slice(0, 1), 4, 5, 6);
-      list.diffAppend(array.slice(0, 2), 8, 9);
-      list.diffAppend(array.slice(0, 3), 6, 7, 5);
 
       expect(list.get()).toEqual(expectedResult);
     });

--- a/src/js/view/components/helpers/measureHelper.js
+++ b/src/js/view/components/helpers/measureHelper.js
@@ -39,6 +39,9 @@ export const calculateWraps = (lines, charSize, elementWidth) => {
  * Works on any object that has a length, and objects that don't have lengths count as -Infinity, which in most if not all cases means ignoring them
  */
 export const maxLengthReducer = (max, next) => {
-  const length = next && next.length ? next.length : -Infinity;
+  const length =
+    next && next.length && typeof next.length === 'number'
+      ? next.length
+      : -Infinity;
   return max > length ? max : length;
 };

--- a/src/js/view/components/helpers/measureHelper.js
+++ b/src/js/view/components/helpers/measureHelper.js
@@ -1,0 +1,13 @@
+/**
+ *
+ * @param {html} content
+ * @param {html container} ruler
+ */
+export const calculateSize = (content, ruler) => {
+  ruler.innerHTML = content;
+  return [ruler.offsetHeight, ruler.offsetWidth];
+};
+
+export const calculateWrap = ([charHeight, charWidth], text, elementWidth) => {
+  return Math.ceil((charWidth * [...text].length) / elementWidth) * charHeight;
+};

--- a/src/js/view/components/helpers/measureHelper.js
+++ b/src/js/view/components/helpers/measureHelper.js
@@ -11,3 +11,9 @@ export const calculateSize = (content, ruler) => {
 export const calculateWrap = ([charHeight, charWidth], text, elementWidth) => {
   return Math.ceil((charWidth * [...text].length) / elementWidth) * charHeight;
 };
+
+export const maxLength = list => {
+  return list.reduce((max, next) => {
+    return max > next.length ? max : next.length;
+  }, 0);
+};

--- a/src/js/view/components/helpers/measureHelper.js
+++ b/src/js/view/components/helpers/measureHelper.js
@@ -1,17 +1,30 @@
 /**
- *
- * @param {html} content
- * @param {html container} ruler
+ * Puts the text in the ruler HTML element and returns the height and width
+ * @param {string} text
+ * @param {HTMLElement} ruler
+ * @returns {Number[]} [height, width]
  */
-export const calculateSize = (content, ruler) => {
-  ruler.innerHTML = content;
+export const calculateSize = (text, ruler) => {
+  ruler.innerHTML = text;
   return [ruler.offsetHeight, ruler.offsetWidth];
 };
 
-export const calculateWrap = ([charHeight, charWidth], text, elementWidth) => {
+/**
+ * Returns the height of text given a charSize and an elementWidth to wrap at
+ * @param {string} text
+ * @param {Number[]} charSize [height, width]
+ * @param {Number} elementWidth The width of where to wrap
+ * @returns {Number} The height of the text, if wrapped
+ */
+export const calculateWrap = (text, [charHeight, charWidth], elementWidth) => {
   return Math.ceil((charWidth * [...text].length) / elementWidth) * charHeight;
 };
 
+/**
+ * Returns the length of the longest string in a list
+ * @param {string[]} list
+ * @returns {Number} The length of the longest string
+ */
 export const maxLength = list => {
   return list.reduce((max, next) => {
     return max > next.length ? max : next.length;

--- a/src/js/view/components/helpers/measureHelper.js
+++ b/src/js/view/components/helpers/measureHelper.js
@@ -19,3 +19,13 @@ export const calculateSize = (text, ruler) => {
 export const calculateWrap = (text, [charHeight, charWidth], elementWidth) => {
   return Math.ceil((charWidth * [...text].length) / elementWidth) * charHeight;
 };
+
+export const calculateWraps = (lines, charSize, elementWidth) => {
+  return lines.map(line => {
+    return calculateWrap(line, charSize, elementWidth);
+  });
+};
+
+export const maxLengthReducer = (max, next) => {
+  return max > next.length ? max : next.length;
+};

--- a/src/js/view/components/helpers/measureHelper.js
+++ b/src/js/view/components/helpers/measureHelper.js
@@ -11,12 +11,21 @@ export const calculateSize = (text, ruler) => {
 
 /**
  * Returns the height of text given a charSize and an elementWidth to wrap at
+ * Returns undefined if elementWidth is 0 or less, charHeight or charWidth are negative or if the charWidth is more than the elementWidth
  * @param {string} text
- * @param {Number[]} charSize [height, width]
- * @param {Number} elementWidth The width of where to wrap
+ * @param {Number[]} charSize [height, width] height and width needs to be positive, and width has to be lower than elementWidth
+ * @param {Number} elementWidth The width of where to wrap, needs to be positive
  * @returns {Number} The height of the text, if wrapped
  */
 export const calculateWrap = (text, [charHeight, charWidth], elementWidth) => {
+  if (
+    elementWidth <= 0 ||
+    charHeight < 0 ||
+    charWidth < 0 ||
+    charWidth > elementWidth
+  )
+    return undefined;
+
   return Math.ceil((charWidth * [...text].length) / elementWidth) * charHeight;
 };
 
@@ -26,6 +35,10 @@ export const calculateWraps = (lines, charSize, elementWidth) => {
   });
 };
 
+/**
+ * Works on any object that has a length, and objects that don't have lengths count as -Infinity, which in most if not all cases means ignoring them
+ */
 export const maxLengthReducer = (max, next) => {
-  return max > next.length ? max : next.length;
+  const length = next && next.length ? next.length : -Infinity;
+  return max > length ? max : length;
 };

--- a/src/js/view/components/helpers/measureHelper.js
+++ b/src/js/view/components/helpers/measureHelper.js
@@ -17,19 +17,25 @@ export const calculateSize = (text, ruler) => {
  * @param {Number} elementWidth The width of where to wrap, needs to be positive
  * @returns {Number} The height of the text, if wrapped
  */
-export const calculateWrap = (text, [charHeight, charWidth], elementWidth) => {
+export const calculateWrappedHeight = (
+  text,
+  [charHeight, charWidth],
+  elementWidth
+) => {
+  if (charWidth < 0 || charHeight < 0)
+    throw new Error('character size has negative values');
+
+  if (charWidth > elementWidth)
+    throw new Error('character width is wider than element width: ', {
+      charWidth: charWidth,
+      elementWidth: elementWidth
+    });
+
+  if (elementWidth <= 0)
+    throw new Error('element width is equal or less to 0: ', elementWidth);
+
   const usableWidth = elementWidth - (elementWidth % charWidth);
-
-  if (usableWidth <= 0 || charHeight < 0 || charWidth < 0 || elementWidth <= 0)
-    return undefined;
-
   return Math.ceil((charWidth * [...text].length) / usableWidth) * charHeight;
-};
-
-export const calculateWraps = (lines, charSize, elementWidth) => {
-  return lines.map(line => {
-    return calculateWrap(line, charSize, elementWidth);
-  });
 };
 
 /**

--- a/src/js/view/components/helpers/measureHelper.js
+++ b/src/js/view/components/helpers/measureHelper.js
@@ -18,15 +18,12 @@ export const calculateSize = (text, ruler) => {
  * @returns {Number} The height of the text, if wrapped
  */
 export const calculateWrap = (text, [charHeight, charWidth], elementWidth) => {
-  if (
-    elementWidth <= 0 ||
-    charHeight < 0 ||
-    charWidth < 0 ||
-    charWidth > elementWidth
-  )
+  const usableWidth = elementWidth - (elementWidth % charWidth);
+
+  if (usableWidth <= 0 || charHeight < 0 || charWidth < 0 || elementWidth <= 0)
     return undefined;
 
-  return Math.ceil((charWidth * [...text].length) / elementWidth) * charHeight;
+  return Math.ceil((charWidth * [...text].length) / usableWidth) * charHeight;
 };
 
 export const calculateWraps = (lines, charSize, elementWidth) => {

--- a/src/js/view/components/helpers/measureHelper.js
+++ b/src/js/view/components/helpers/measureHelper.js
@@ -19,14 +19,3 @@ export const calculateSize = (text, ruler) => {
 export const calculateWrap = (text, [charHeight, charWidth], elementWidth) => {
   return Math.ceil((charWidth * [...text].length) / elementWidth) * charHeight;
 };
-
-/**
- * Returns the length of the longest string in a list
- * @param {string[]} list
- * @returns {Number} The length of the longest string
- */
-export const maxLength = list => {
-  return list.reduce((max, next) => {
-    return max > next.length ? max : next.length;
-  }, 0);
-};

--- a/src/js/view/components/helpers/measureHelper.test.js
+++ b/src/js/view/components/helpers/measureHelper.test.js
@@ -1,23 +1,35 @@
-import { calculateWrap, maxLengthReducer } from './measureHelper';
+import { calculateWrappedHeight, maxLengthReducer } from './measureHelper';
 
 describe('calculateSize', () => {});
-describe('calculateWrap', () => {
-  it('should be undefined if the width is 0', () => {
+describe('calculateWrappedHeight', () => {
+  it('should throw error if the width is 0', () => {
     const text = '';
     const charSize = [0, 0];
     const elementWidth = 0;
-    const expectedResult = undefined;
 
-    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+    expect(() => {
+      calculateWrappedHeight(text, charSize, elementWidth);
+    }).toThrow();
   });
 
-  it('should be undefined if the width is < 0', () => {
+  it('should throw error if the width is < 0', () => {
     const text = '';
     const charSize = [0, 0];
     const elementWidth = -1;
-    const expectedResult = undefined;
 
-    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+    expect(() => {
+      calculateWrappedHeight(text, charSize, elementWidth);
+    }).toThrow();
+  });
+
+  it('should throw error if the character width is higher than the elementWidth', () => {
+    const text = '123';
+    const charSize = [1, 100];
+    const elementWidth = 1;
+
+    expect(() => {
+      calculateWrappedHeight(text, charSize, elementWidth);
+    }).toThrow();
   });
 
   it('should be wrapped by width', () => {
@@ -26,7 +38,9 @@ describe('calculateWrap', () => {
     const elementWidth = 5;
     const expectedResult = 8;
 
-    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+    expect(calculateWrappedHeight(text, charSize, elementWidth)).toEqual(
+      expectedResult
+    );
   });
 
   it('should contain not full rows', () => {
@@ -35,16 +49,9 @@ describe('calculateWrap', () => {
     const elementWidth = 5;
     const expectedResult = 12;
 
-    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
-  });
-
-  it('should be undefined if the charWidth is higher than the elementWidth', () => {
-    const text = '123';
-    const charSize = [1, 100];
-    const elementWidth = 1;
-    const expectedResult = undefined;
-
-    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+    expect(calculateWrappedHeight(text, charSize, elementWidth)).toEqual(
+      expectedResult
+    );
   });
 
   it('should be move down overflowing character to next line', () => {
@@ -53,7 +60,9 @@ describe('calculateWrap', () => {
     const elementWidth = 5;
     const expectedResult = 20;
 
-    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+    expect(calculateWrappedHeight(text, charSize, elementWidth)).toEqual(
+      expectedResult
+    );
   });
 });
 

--- a/src/js/view/components/helpers/measureHelper.test.js
+++ b/src/js/view/components/helpers/measureHelper.test.js
@@ -1,9 +1,4 @@
-import {
-  calculateSize,
-  calculateWrap,
-  calculateWraps,
-  maxLengthReducer
-} from './measureHelper';
+import { calculateWrap, maxLengthReducer } from './measureHelper';
 
 describe('calculateSize', () => {});
 describe('calculateWrap', () => {

--- a/src/js/view/components/helpers/measureHelper.test.js
+++ b/src/js/view/components/helpers/measureHelper.test.js
@@ -46,6 +46,15 @@ describe('calculateWrap', () => {
 
     expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
   });
+
+  it('should be move down overflowing character to next line', () => {
+    const text = '0123456789';
+    const charSize = [2, 3];
+    const elementWidth = 5;
+    const expectedResult = 20;
+
+    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+  });
 });
 
 describe('maxLengthReducer', () => {

--- a/src/js/view/components/helpers/measureHelper.test.js
+++ b/src/js/view/components/helpers/measureHelper.test.js
@@ -1,0 +1,109 @@
+import {
+  calculateSize,
+  calculateWrap,
+  calculateWraps,
+  maxLengthReducer
+} from './measureHelper';
+
+describe('calculateSize', () => {});
+describe('calculateWrap', () => {
+  it('should be undefined if the width is 0', () => {
+    const text = '';
+    const charSize = [0, 0];
+    const elementWidth = 0;
+    const expectedResult = undefined;
+
+    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+  });
+
+  it('should be undefined if the width is < 0', () => {
+    const text = '';
+    const charSize = [0, 0];
+    const elementWidth = -1;
+    const expectedResult = undefined;
+
+    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+  });
+
+  it('should be wrapped by width', () => {
+    const text = '0123456789';
+    const charSize = [4, 1];
+    const elementWidth = 5;
+    const expectedResult = 8;
+
+    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+  });
+
+  it('should contain not full rows', () => {
+    const text = '01234567891';
+    const charSize = [4, 1];
+    const elementWidth = 5;
+    const expectedResult = 12;
+
+    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+  });
+
+  it('should be undefined if the charWidth is higher than the elementWidth', () => {
+    const text = '123';
+    const charSize = [1, 100];
+    const elementWidth = 1;
+    const expectedResult = undefined;
+
+    expect(calculateWrap(text, charSize, elementWidth)).toEqual(expectedResult);
+  });
+});
+
+describe('maxLengthReducer', () => {
+  it('should return start value', () => {
+    const array = [];
+    const startValue = 5;
+    const expectedResult = 5;
+
+    expect(array.reduce(maxLengthReducer, startValue)).toEqual(expectedResult);
+  });
+  it('should return maximum length', () => {
+    const array = ['123123123', '123', '132575684566qdsfdasf', '235'];
+    const expectedResult = 20;
+
+    expect(array.reduce(maxLengthReducer, 0)).toEqual(expectedResult);
+  });
+
+  it('should ignore undefined values', () => {
+    const array = ['12', '123', undefined, '123123123'];
+    const expectedResult = 9;
+
+    expect(array.reduce(maxLengthReducer, 0)).toEqual(expectedResult);
+  });
+
+  it('should ignore values without length', () => {
+    const array = ['ju', '123', {}, '235', '123123123'];
+    const expectedResult = 9;
+
+    expect(array.reduce(maxLengthReducer, 0)).toEqual(expectedResult);
+  });
+
+  it('should work on arrays', () => {
+    const array = [[1, 2, 3], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [4, 5, 6, 7]];
+    const expectedResult = 10;
+
+    expect(array.reduce(maxLengthReducer, 0)).toEqual(expectedResult);
+  });
+
+  it('should work on mixed objects', () => {
+    const array = [
+      'hejhjejejhje',
+      [1, 2, 3, 4, 5, 6, 7, 8, 9],
+      { length: 100 }
+    ];
+    const expectedResult = 100;
+
+    expect(array.reduce(maxLengthReducer, 0)).toEqual(expectedResult);
+  });
+
+  it('should ignore numbers', () => {
+    const array = [1, 2, 3, '123', 100];
+    const expectedResult = 3;
+
+    expect(array.reduce(maxLengthReducer, 0)).toEqual(expectedResult);
+  });
+});

--- a/src/js/view/styledComponents/LogViewerListStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerListStyledComponents.js
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+import Color from 'color';
+
+export const LogViewerListContainer = styled.div`
+  min-width: 100%;
+  overflow: auto;
+`;
+
+export const LogLine = styled.div`
+  background: ${props => {
+    const color = '#444';
+    return props.index & 1
+      ? color
+      : Color(color)
+          .darken(0.3)
+          .hex();
+  }};
+  ${props => {
+    return props.fixedWidth ? 'width: ' + props.fixedWidth + 'px;' : '';
+  }}
+
+  ${props => {
+    return props.fixedHeight ? 'height: ' + props.fixedHeight + 'px;' : '';
+  }}
+  ${props => {
+    return props.wrap
+      ? `
+    word-wrap: break-word;
+    word-break: break-all;`
+      : 'white-space: nowrap;';
+  }};
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+`;

--- a/src/js/view/styledComponents/LogViewerListStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerListStyledComponents.js
@@ -32,3 +32,10 @@ export const LogLine = styled.div`
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 `;
+
+export const LogLineRuler = styled(LogLine)`
+  visibility: hidden;
+  min-width: 0px;
+  position: absolute;
+  display: inline-block;
+`;

--- a/src/js/view/styledComponents/LogViewerListStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerListStyledComponents.js
@@ -7,6 +7,7 @@ export const LogViewerListContainer = styled.div`
 `;
 
 export const LogLine = styled.div`
+  min-width: 100%;
   background: ${props => {
     const color = '#444';
     return props.index & 1

--- a/src/js/view/styledComponents/LogViewerStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerStyledComponents.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
-import Color from 'color';
 
-export const LogViewContainer = styled.div`
+export const LogViewerContainer = styled.div`
   display: flex;
   flex: 1;
   border: 1px solid white;
@@ -10,37 +9,6 @@ export const LogViewContainer = styled.div`
   max-height: 100%;
   overflow-anchor: none;
   min-width: 0;
-`;
-
-export const Log = styled.div`
-  min-width: 100%;
-  overflow: auto;
-  div {
-    min-width: 100%;
-  }
-`;
-
-export const LogLine = styled.div`
-  background: ${props => {
-    const color = '#444';
-    return props.index & 1
-      ? color
-      : Color(color)
-          .darken(0.3)
-          .hex();
-  }};
-  ${props => {
-    return props.fixedWidth ? 'width: ' + props.fixedWidth + 'px;' : '';
-  }}
-  ${props => {
-    return props.wrap
-      ? `
-    word-wrap: break-word;
-    word-break: break-all;`
-      : 'white-space: nowrap;';
-  }};
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
 `;
 
 export const CloseFileButton = styled.button`

--- a/src/js/view/styledComponents/LogViewerStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerStyledComponents.js
@@ -16,7 +16,6 @@ export const Log = styled.div`
   min-width: 100%;
   overflow: auto;
   div {
-    display: inline-block;
     min-width: 100%;
   }
 `;
@@ -31,13 +30,17 @@ export const LogLine = styled.div`
           .hex();
   }};
   ${props => {
+    return props.fixedWidth ? 'width: ' + props.fixedWidth + 'px;' : '';
+  }}
+  ${props => {
     return props.wrap
       ? `
-    overflow-wrap: break-word;
     word-wrap: break-word;
     word-break: break-all;`
       : 'white-space: nowrap;';
   }};
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
 `;
 
 export const CloseFileButton = styled.button`


### PR DESCRIPTION
This pull request will fix the bug with sizing errors when wrapping lines and add caching for lines

Previously the height of the windowed list was calculated incorrectly when wrapping lines of different sizes as the heights would not be uniform. This is remedied by changing the type of the windowed list from 'uniform' to 'variable' and by calculating the height of each individual element.

To avoid rendering each element and then rendering each height one character is rendered that is then used to estimate the width and height of each element. As this is done mathematically for each element, it's quite performant. However doing this operation is _only_ necessary when resizing the window or if the content of the list is changed (ie: a filter is used) so caching for lines and their respective sizes have been set up.

To be able to measure the width of each log line, the font for the log has been changed to a monospaced font. We could support non-monospaced fonts but we'd have to measure based on the widest character and will overshoot the longer the line is.

The Log is refactored into its own component (LogViewerList) as it was starting to bloat the LogViewer component.