### PR TITLE
Add snackbar component, and add it to the app

### DIFF
--- a/src/js/view/App.js
+++ b/src/js/view/App.js
@@ -2,7 +2,8 @@ import TabSettings from './components/TabSettings';
 import LogViewer from './components/LogViewer';
 import TopPanel from './components/TopPanel';
 import DefaultPage from './components/DefaultPage';
-import Statusbar from './components/StatusBar';
+import StatusBar from './components/StatusBar';
+import SnackBar from './components/SnackBar';
 import {
   RootContainer,
   LogPage
@@ -20,7 +21,8 @@ class App extends Component {
             <TopPanel />
             <TabSettings />
             <LogViewer />
-            <Statusbar />
+            <StatusBar />
+            <SnackBar />
           </LogPage>
         ) : (
           <DefaultPage />

--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -62,16 +62,20 @@ export const handleCloseFile = dispatch => {
 
 export const hideSnackBar = (dispatch, instant) => {
   dispatch({
-    type: 'snackbar_hide',
-    instant: instant
+    type: 'SNACKBAR_HIDE',
+    data: {
+      instant
+    }
   });
 };
 
 export const showSnackBar = (dispatch, message, level, fadeAfter) => {
   dispatch({
-    type: 'snackbar_show_new',
-    message: message,
-    level: level,
-    fadeAfter: fadeAfter
+    type: 'SNACKBAR_SHOW_NEW',
+    data: {
+      message,
+      level,
+      fadeAfter
+    }
   });
 };

--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -59,3 +59,19 @@ export const handleCloseFile = dispatch => {
     data: ''
   });
 };
+
+export const hideSnackBar = (dispatch, instant) => {
+  dispatch({
+    type: 'snackbar_hide',
+    instant: instant
+  });
+};
+
+export const showSnackBar = (dispatch, message, level, fadeAfter) => {
+  dispatch({
+    type: 'snackbar_show_new',
+    message: message,
+    level: level,
+    fadeAfter: fadeAfter
+  });
+};

--- a/src/js/view/components/SnackBar.js
+++ b/src/js/view/components/SnackBar.js
@@ -8,15 +8,15 @@ import {
 import { connect } from 'react-redux';
 import CommonSnackBar from 'js/view/components/common/snackbar/SnackBar';
 
-function SnackBar(props) {
+const SnackBar = props => {
   return (
     <CommonSnackBar
-      key={props.snackBar.message + props.snackBar.level}
-      show={props.snackBar.show}
-      fadeAfter={props.snackBar.fadeAfter}
+      key={props.message + props.level}
+      show={props.show}
+      fadeAfter={props.fadeAfter}
     >
       <Layout row>
-        <Container grow>{props.snackBar.message}</Container>
+        <Container grow>{props.message}</Container>
         <Container>
           <TextButton
             color="#bb86fc"
@@ -30,11 +30,14 @@ function SnackBar(props) {
       </Layout>
     </CommonSnackBar>
   );
-}
+};
 
 const mapStateToProps = state => {
   return {
-    snackBar: state.snackBarReducer
+    message: state.snackBarReducer.message,
+    show: state.snackBarReducer.show,
+    fadeAfter: state.snackBarReducer.fadeAfter,
+    level: state.snackBarReducer.level
   };
 };
 

--- a/src/js/view/components/SnackBar.js
+++ b/src/js/view/components/SnackBar.js
@@ -24,7 +24,7 @@ function SnackBar(props) {
               hideSnackBar(props.dispatch, true);
             }}
           >
-            CLOSE
+            DISMISS
           </TextButton>
         </Container>
       </Layout>

--- a/src/js/view/components/SnackBar.js
+++ b/src/js/view/components/SnackBar.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { TextButton } from 'js/view/styledComponents/common/ButtonStyledComponents';
+import { hideSnackBar } from 'js/view/actions/dispatchActions';
+import {
+  Container,
+  Layout
+} from 'js/view/styledComponents/common/FlexBoxStyledComponents';
+import { connect } from 'react-redux';
+import CommonSnackBar from 'js/view/components/common/snackbar/SnackBar';
+
+function SnackBar(props) {
+  return (
+    <CommonSnackBar
+      key={props.snackBar.message + props.snackBar.level}
+      show={props.snackBar.show}
+      fadeAfter={props.snackBar.fadeAfter}
+    >
+      <Layout row>
+        <Container grow>{props.snackBar.message}</Container>
+        <Container>
+          <TextButton
+            color="#bb86fc"
+            onClick={() => {
+              hideSnackBar(props.dispatch, true);
+            }}
+          >
+            CLOSE
+          </TextButton>
+        </Container>
+      </Layout>
+    </CommonSnackBar>
+  );
+}
+
+const mapStateToProps = state => {
+  return {
+    snackBar: state.snackBarReducer
+  };
+};
+
+export default connect(mapStateToProps)(SnackBar);

--- a/src/js/view/components/common/snackbar/SnackBar.js
+++ b/src/js/view/components/common/snackbar/SnackBar.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
-import styled from 'styled-components';
+import { SnackBarContainer } from 'js/view/styledComponents/common/SnackBarStyledComponents';
 
 export default function SnackBar(props) {
   const [show, setShow] = useState(false);
@@ -20,90 +20,12 @@ export default function SnackBar(props) {
   }, [props.show]);
 
   return (
-    <SnackbarContainer
+    <SnackBarContainer
       fadeOut={props.fadeAfter > 0}
       color={props.color}
       className={show ? 'show' : 'hide'}
     >
       {props.children}
-    </SnackbarContainer>
+    </SnackBarContainer>
   );
 }
-
-const SnackbarContainer = styled.div`
-  position: absolute;
-  min-width: 50%;
-  visibility: hidden;
-  background-color: ${props => {
-    return props.color ? props.color : '#333';
-  }};
-  color: #ccc;
-  bottom: 20px;
-  left: 10px;
-  padding: 10px 16px;
-  border-radius: 4px;
-  z-index: 8;
-
-  &.show {
-    visibility: visible;
-    -webkit-animation: fadein 0.5s;
-    animation: fadein 0.5s;
-  }
-
-  &.hide {
-    ${props => {
-      return props.fadeOut
-        ? `
-    -webkit-animation: fadeout 1.5s;
-    animation: fadeout 1.5s;
-    `
-        : '';
-    }}
-  }
-
-  @-webkit-keyframes fadein {
-    from {
-      bottom: 0;
-      opacity: 0;
-    }
-    to {
-      bottom: 20px;
-      opacity: 1;
-    }
-  }
-
-  @keyframes fadein {
-    from {
-      bottom: 0;
-      opacity: 0;
-    }
-    to {
-      bottom: 20px;
-      opacity: 1;
-    }
-  }
-
-  @-webkit-keyframes fadeout {
-    from {
-      bottom: 20px;
-      opacity: 1;
-      visibility: visible;
-    }
-    to {
-      bottom: 0;
-      opacity: 0;
-    }
-  }
-
-  @keyframes fadeout {
-    from {
-      bottom: 20px;
-      opacity: 1;
-      visibility: visible;
-    }
-    to {
-      bottom: 0;
-      opacity: 0;
-    }
-  }
-`;

--- a/src/js/view/components/common/snackbar/SnackBar.js
+++ b/src/js/view/components/common/snackbar/SnackBar.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { SnackBarContainer } from 'js/view/styledComponents/common/SnackBarStyledComponents';
 
 export default function SnackBar(props) {

--- a/src/js/view/components/common/snackbar/SnackBar.js
+++ b/src/js/view/components/common/snackbar/SnackBar.js
@@ -1,0 +1,111 @@
+import React, { useRef, useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+export default function SnackBar(props) {
+  const [show, setShow] = useState(false);
+  const ref = useRef();
+
+  useEffect(() => {
+    let timeout;
+
+    setShow(props.show);
+    if (props.fadeAfter > 0 && props.show) {
+      timeout = setTimeout(() => {
+        setShow(false);
+      }, props.fadeAfter);
+    }
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [props.show]);
+
+  return (
+    <SnackbarContainer
+      ref={ref}
+      fade={props.fadeAfter > 0}
+      color={props.color}
+      className={show ? 'show' : 'hide'}
+    >
+      {props.children}
+    </SnackbarContainer>
+  );
+}
+
+const SnackbarContainer = styled.div`
+  position: absolute;
+  min-width: 50%;
+  visibility: hidden;
+  background-color: ${props => {
+    return props.color ? props.color : '#333';
+  }};
+  color: #ccc;
+  bottom: 20px;
+  left: 10px;
+  padding: 10px 16px;
+  border-radius: 4px;
+  z-index: 8;
+
+  &.show {
+    visibility: visible;
+    -webkit-animation: fadein 0.5s;
+    animation: fadein 0.5s;
+  }
+
+  &.hide {
+    ${props => {
+      return props.fade
+        ? `
+    -webkit-animation: fadeout 1.5s;
+    animation: fadeout 1.5s;
+    `
+        : '';
+    }}
+  }
+
+  @-webkit-keyframes fadein {
+    from {
+      bottom: 0;
+      opacity: 0;
+    }
+    to {
+      bottom: 20px;
+      opacity: 1;
+    }
+  }
+
+  @keyframes fadein {
+    from {
+      bottom: 0;
+      opacity: 0;
+    }
+    to {
+      bottom: 20px;
+      opacity: 1;
+    }
+  }
+
+  @-webkit-keyframes fadeout {
+    from {
+      bottom: 20px;
+      opacity: 1;
+      visibility: visible;
+    }
+    to {
+      bottom: 0;
+      opacity: 0;
+    }
+  }
+
+  @keyframes fadeout {
+    from {
+      bottom: 20px;
+      opacity: 1;
+      visibility: visible;
+    }
+    to {
+      bottom: 0;
+      opacity: 0;
+    }
+  }
+`;

--- a/src/js/view/components/common/snackbar/SnackBar.js
+++ b/src/js/view/components/common/snackbar/SnackBar.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 export default function SnackBar(props) {
   const [show, setShow] = useState(false);
-  const ref = useRef();
 
   useEffect(() => {
     let timeout;
@@ -22,7 +21,6 @@ export default function SnackBar(props) {
 
   return (
     <SnackbarContainer
-      ref={ref}
       fade={props.fadeAfter > 0}
       color={props.color}
       className={show ? 'show' : 'hide'}

--- a/src/js/view/components/common/snackbar/SnackBar.js
+++ b/src/js/view/components/common/snackbar/SnackBar.js
@@ -21,7 +21,7 @@ export default function SnackBar(props) {
 
   return (
     <SnackbarContainer
-      fade={props.fadeAfter > 0}
+      fadeOut={props.fadeAfter > 0}
       color={props.color}
       className={show ? 'show' : 'hide'}
     >
@@ -52,7 +52,7 @@ const SnackbarContainer = styled.div`
 
   &.hide {
     ${props => {
-      return props.fade
+      return props.fadeOut
         ? `
     -webkit-animation: fadeout 1.5s;
     animation: fadeout 1.5s;

--- a/src/js/view/components/common/snackbar/SnackBar.js
+++ b/src/js/view/components/common/snackbar/SnackBar.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { SnackBarContainer } from 'js/view/styledComponents/common/SnackBarStyledComponents';
 
-export default function SnackBar(props) {
+const SnackBar = props => {
   const [show, setShow] = useState(false);
 
   useEffect(() => {
@@ -28,4 +28,6 @@ export default function SnackBar(props) {
       {props.children}
     </SnackBarContainer>
   );
-}
+};
+
+export default SnackBar;

--- a/src/js/view/reducers/index.js
+++ b/src/js/view/reducers/index.js
@@ -4,13 +4,15 @@ import { logViewerReducer } from './logViewerReducer';
 import { menuReducer } from './menuReducer';
 import { settingsReducer } from './settingsReducer';
 import { topPanelReducer } from './topPanelReducer';
+import { snackBarReducer } from './snackBarReducer';
 
 const reducers = combineReducers({
   logInfoReducer,
   logViewerReducer,
   menuReducer,
   settingsReducer,
-  topPanelReducer
+  topPanelReducer,
+  snackBarReducer
 });
 
 export default reducers;

--- a/src/js/view/reducers/snackBarReducer.js
+++ b/src/js/view/reducers/snackBarReducer.js
@@ -1,0 +1,22 @@
+const initialState = { show: false, message: '', level: 'info', fadeAfter: 0 };
+
+export const snackBarReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case 'snackbar_show_new':
+      return {
+        ...state,
+        show: true,
+        message: action.message,
+        level: action.level ? action.level : initialState.level,
+        fadeAfter: action.fadeAfter ? action.fadeAfter : initialState.fadeAfter
+      };
+    case 'snackbar_hide':
+      return {
+        ...state,
+        show: false,
+        fadeAfter: action.instant ? 0 : state.fadeAfter
+      };
+    default:
+      return state;
+  }
+};

--- a/src/js/view/reducers/snackBarReducer.js
+++ b/src/js/view/reducers/snackBarReducer.js
@@ -2,19 +2,21 @@ const initialState = { show: false, message: '', level: 'info', fadeAfter: 0 };
 
 export const snackBarReducer = (state = initialState, action) => {
   switch (action.type) {
-    case 'snackbar_show_new':
+    case 'SNACKBAR_SHOW_NEW':
+      const { message, level, fadeAfter } = action.data;
       return {
         ...state,
         show: true,
-        message: action.message,
-        level: action.level ? action.level : initialState.level,
-        fadeAfter: action.fadeAfter ? action.fadeAfter : initialState.fadeAfter
+        message: message,
+        level: level ? level : initialState.level,
+        fadeAfter: fadeAfter ? fadeAfter : initialState.fadeAfter
       };
-    case 'snackbar_hide':
+    case 'SNACKBAR_HIDE':
+      const { instant } = action.data;
       return {
         ...state,
         show: false,
-        fadeAfter: action.instant ? 0 : state.fadeAfter
+        fadeAfter: instant ? 0 : state.fadeAfter
       };
     default:
       return state;

--- a/src/js/view/reducers/snackBarReducer.test.js
+++ b/src/js/view/reducers/snackBarReducer.test.js
@@ -22,7 +22,8 @@ describe('snackbar reducer', () => {
       show: false
     };
     const action = {
-      type: 'snackbar_hide'
+      type: 'SNACKBAR_HIDE',
+      data: { instant: false }
     };
     expect(snackBarReducer(state, action)).toEqual(expectedResult);
   });
@@ -39,8 +40,8 @@ describe('snackbar reducer', () => {
       fadeAfter: 0
     };
     const action = {
-      type: 'snackbar_hide',
-      instant: true
+      type: 'SNACKBAR_HIDE',
+      data: { instant: true }
     };
     expect(snackBarReducer(state, action)).toEqual(expectedResult);
   });
@@ -61,8 +62,8 @@ describe('snackbar reducer', () => {
       ...content
     };
     const action = {
-      type: 'snackbar_show_new',
-      ...content
+      type: 'SNACKBAR_SHOW_NEW',
+      data: { ...content }
     };
     expect(snackBarReducer(state, action)).toEqual(expectedResult);
   });

--- a/src/js/view/reducers/snackBarReducer.test.js
+++ b/src/js/view/reducers/snackBarReducer.test.js
@@ -1,0 +1,69 @@
+import { snackBarReducer } from './snackBarReducer';
+
+describe('snackbar reducer', () => {
+  const initialState = {
+    show: false,
+    message: '',
+    level: 'info',
+    fadeAfter: 0
+  };
+
+  it('should return the initial state', () => {
+    expect(snackBarReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should set show to false', () => {
+    const state = {
+      ...initialState,
+      show: true
+    };
+    const expectedResult = {
+      ...initialState,
+      show: false
+    };
+    const action = {
+      type: 'snackbar_hide'
+    };
+    expect(snackBarReducer(state, action)).toEqual(expectedResult);
+  });
+
+  it('should set show to false and turn off fade', () => {
+    const state = {
+      ...initialState,
+      show: true,
+      fadeAfter: 100
+    };
+    const expectedResult = {
+      ...initialState,
+      show: false,
+      fadeAfter: 0
+    };
+    const action = {
+      type: 'snackbar_hide',
+      instant: true
+    };
+    expect(snackBarReducer(state, action)).toEqual(expectedResult);
+  });
+
+  it('should set show to true and update state', () => {
+    const state = {
+      ...initialState,
+      show: false
+    };
+    const content = {
+      message: 'message',
+      level: 'error',
+      fadeAfter: 100
+    };
+    const expectedResult = {
+      ...initialState,
+      show: true,
+      ...content
+    };
+    const action = {
+      type: 'snackbar_show_new',
+      ...content
+    };
+    expect(snackBarReducer(state, action)).toEqual(expectedResult);
+  });
+});

--- a/src/js/view/styledComponents/common/ButtonStyledComponents.js
+++ b/src/js/view/styledComponents/common/ButtonStyledComponents.js
@@ -11,6 +11,23 @@ export const OpenFileButton = styled.button`
   outline: none;
 `;
 
+export const TextButton = styled.button`
+  border: none;
+  background-color: inherit;
+  color: ${props => {
+    return props.color ? props.color : '#222';
+  }};
+  padding: 14px 28px;
+  font-size: 16px;
+  cursor: pointer;
+  display: inline-block;
+  outline: none;
+
+  :hover {
+    background: rgba(0, 0, 0, 0.1);
+  }
+`;
+
 export const SwitchButtonContainer = styled.label`
   position: relative;
   display: inline-block;

--- a/src/js/view/styledComponents/common/FlexBoxStyledComponents.js
+++ b/src/js/view/styledComponents/common/FlexBoxStyledComponents.js
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: ${props => {
+    return props.column ? 'column' : 'row';
+  }};
+  flex: 1;
+
+  align-items ${props => {
+    if (props.alignStart) return 'flex-start';
+    if (props.alignEnd) return 'flex-end';
+    if (props.alignCenter) return 'center';
+    if (props.alignStretch) return 'stretch';
+
+    return 'baseline';
+  }};
+`;
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: ${props => {
+    return props.column ? 'column' : 'row';
+  }};
+  flex-grow: ${props => {
+    return props.grow ? '1' : '0';
+  }};
+  flex-shrink: ${props => {
+    return props.shrink ? '1' : '0';
+  }};
+`;

--- a/src/js/view/styledComponents/common/SnackBarStyledComponents.js
+++ b/src/js/view/styledComponents/common/SnackBarStyledComponents.js
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+
+export const SnackbarContainer = styled.div`
+  position: absolute;
+  min-width: 50%;
+  visibility: hidden;
+  background-color: ${props => {
+    return props.color ? props.color : '#333';
+  }};
+  color: #ccc;
+  bottom: 20px;
+  left: 10px;
+  padding: 10px 16px;
+  border-radius: 4px;
+  z-index: 8;
+
+  &.show {
+    visibility: visible;
+    -webkit-animation: fadein 0.5s;
+    animation: fadein 0.5s;
+  }
+
+  &.hide {
+    ${props => {
+      return props.fadeOut
+        ? `
+    -webkit-animation: fadeout 1.5s;
+    animation: fadeout 1.5s;
+    `
+        : '';
+    }}
+  }
+
+  @-webkit-keyframes fadein {
+    from {
+      bottom: 0;
+      opacity: 0;
+    }
+    to {
+      bottom: 20px;
+      opacity: 1;
+    }
+  }
+
+  @keyframes fadein {
+    from {
+      bottom: 0;
+      opacity: 0;
+    }
+    to {
+      bottom: 20px;
+      opacity: 1;
+    }
+  }
+
+  @-webkit-keyframes fadeout {
+    from {
+      bottom: 20px;
+      opacity: 1;
+      visibility: visible;
+    }
+    to {
+      bottom: 0;
+      opacity: 0;
+    }
+  }
+
+  @keyframes fadeout {
+    from {
+      bottom: 20px;
+      opacity: 1;
+      visibility: visible;
+    }
+    to {
+      bottom: 0;
+      opacity: 0;
+    }
+  }
+`;

--- a/src/js/view/styledComponents/common/SnackBarStyledComponents.js
+++ b/src/js/view/styledComponents/common/SnackBarStyledComponents.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const SnackbarContainer = styled.div`
+export const SnackBarContainer = styled.div`
   position: absolute;
   min-width: 50%;
   visibility: hidden;


### PR DESCRIPTION
This pull request will add a snackbar component and reducer that can be called to show a snackbar with some kind of message (If you don't know what a snackbar is: https://www.polonel.com/snackbar/)
We could use this component to show relevant messages to the user, such as error messages

I've created two `SnackBar` components, one in `components/common` that is generic and one in `components` that uses the generic one but adds some extra functionality, like a dismiss button that dispatches a hide event.

If we so wish we could style the snackbar further in the future based  on importance level like https://codesandbox.io/s/5kq4jv6vpn but right now the styling is basic

*Motivation*
I tried opening a non-readable file in VS Code and they use a similar notification system



*How to use*
dispatch the action `showSnackBar` or `hideSnackBar` to show / hide the snackbar

If you want to try it out you can import the showSnackBar action to App.js and dispatch in componentDidMount like,

```javascript
import { showSnackBar } from './actions/dispatchActions';

...

class App extends Component {
    componentDidMount() {
        showSnackBar(this.props.dispatch, "IM A MESSAGE", "info", 10000);
    }

    ...
}
```


`showSnackBar` takes three extra arguments, message, level and fadeAfter
*message* is the message displayed
*level* is the type of snackbar message (this is unused right now, but could be useful in the future!)
*fadeAfter* is after how long the snackbar should fade. If not set or 0 then it won't disappear unless you press dismiss (or dispatch hideSnackBar)

`hideSnackBar` takes one extra argument, instant
*instant* if set to a truthy value will set fadeAfter to 0, which will result in the fadeout animation not running when hiding the snackbar
