### PR TITLE
#279 #280 Push file errors to the frontend

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -102,7 +102,7 @@ const createWindow = async () => {
   );
   mainWindow.on('close', () => {
     let argObj = {};
-    argObj.type = 'saveState';
+    argObj.type = '';
     mainWindow.webContents.send('backendMessages', argObj);
   });
   loadingWindow.show();

--- a/public/electron.js
+++ b/public/electron.js
@@ -56,7 +56,7 @@ const windowStateKeeper = windowName => {
   };
 };
 
-const createWindow = () => {
+const createWindow = async () => {
   const mainWindowStateKeeper = windowStateKeeper('main');
   const windowOptions = {
     x: mainWindowStateKeeper.x,
@@ -112,6 +112,13 @@ const createWindow = () => {
     quitApplication();
   });
   menu.setWebContents(mainWindow.webContents);
+
+  try {
+    const recentFiles = await engine.loadRecentFilesFromDisk();
+    menu.setRecentFiles(recentFiles);
+  } catch (err) {
+    console.log("Couldn't load recent files, ", err);
+  }
   menu.createMenu();
 };
 

--- a/public/electron.js
+++ b/public/electron.js
@@ -101,8 +101,7 @@ const createWindow = async () => {
     `file://${path.join(__dirname, '../src/resources/loadingSpinner.html')}`
   );
   mainWindow.on('close', () => {
-    let argObj = {};
-    argObj.type = '';
+    const argObj = { type: 'QUIT' };
     mainWindow.webContents.send('backendMessages', argObj);
   });
   loadingWindow.show();

--- a/src/js/adapters/fileReader.js
+++ b/src/js/adapters/fileReader.js
@@ -55,7 +55,6 @@ const formatLinesFromBuffer = _buffer => {
 //start a watcher and read the new lines starting from the last newline index
 //whenever there is a change to the file.
 const startWatcher = (sender, filePath, lastNewlineIndex) => {
-  console.log(lastNewlineIndex);
   if (watchers[filePath] !== undefined) {
     watchers[filePath].close();
   }

--- a/src/js/adapters/fileReader.js
+++ b/src/js/adapters/fileReader.js
@@ -1,14 +1,9 @@
 const fs = require('fs');
 const lastLines = require('read-last-lines');
-const nthLine = require('nthline');
-const { EventEmitter } = require('events');
 const app = require('electron').app;
 const path = require('path');
 
 let watchers = [];
-
-const fileReaderEvents = new EventEmitter();
-fileReaderEvents.removeAllListeners('liveLines');
 
 const reduxStateFile = () => {
   return path.join(app.getPath('userData'), 'reduxState.json');
@@ -39,37 +34,39 @@ const formatLinesFromBuffer = _buffer => {
 //whenever there is a change to the file.
 const startWatcher = (filePath, fromIndex, onChange, onError) => {
   let currentIndex = fromIndex;
-  let charsSinceLastLine = '';
+  let unusedChars = '';
   if (watchers[filePath] !== undefined) {
     watchers[filePath].close();
   }
   let watcher = fs.watch(filePath, (_event, _filename) => {
-    let readStream = fs
-      .createReadStream(filePath, {
-        start: currentIndex
+    fs.createReadStream(filePath, {
+      start: currentIndex
+    })
+      .setEncoding('utf8')
+      .on('data', chunk => {
+        currentIndex += chunk.length;
+        const [lines, trailingChars] = formatChunk(chunk, unusedChars);
+        unusedChars = trailingChars;
+        if (lines.length > 0) {
+          onChange(lines);
+        }
       })
-      .setEncoding('utf8');
-
-    readStream.on('data', buffer => {
-      currentIndex += buffer.length;
-      const lines = buffer.split(/\r?\n/);
-      lines[0] += charsSinceLastLine;
-      charsSinceLastLine = lines[lines.length - 1];
-      lines[lines.length - 1] = '';
-
-      const filteredLines = lines.filter(x => {
-        return x !== '';
+      .on('error', error => {
+        onError(error);
       });
-      onChange(filteredLines);
-    });
-    readStream.on('error', error => {
-      onError(error);
-    });
   });
 
   watchers[filePath] = watcher;
 };
 
+const formatChunk = (chunk, prevChunkTrailingChars) => {
+  const lines = chunk.split(/\r?\n/);
+  lines[0] += prevChunkTrailingChars;
+  const trailingChars = lines[lines.length - 1];
+  lines.pop();
+
+  return [lines, trailingChars];
+};
 const stopAllWatchers = () => {
   for (var key in watchers) {
     watchers[key].close();
@@ -81,7 +78,6 @@ const stopWatcher = filePath => {
   try {
     watchers[filePath].close();
     delete watchers[filePath];
-    fileReaderEvents.removeAllListeners('liveLines');
     return `successfully closed watcher on file ${filePath}`; //if we want to send a confirmation to the frontend.
   } catch (err) {
     return err;
@@ -92,24 +88,30 @@ const followFile = async (filePath, fromIndex, onChange, onError) => {
   startWatcher(filePath, fromIndex, onChange, onError);
 };
 
-const getNumberOfLines = filePath => {
+const getLinesInfo = (filePath, historyLength = 0) => {
   return new Promise((resolve, reject) => {
     let lineCount = 0;
-    let lastLineEndIndex = 0;
-    let charsSinceLineCount = 0;
+    let endIndex = 0;
+    let history = [];
+    let unusedChars = '';
+
     fs.createReadStream(filePath)
+      .setEncoding('utf8')
       .on('data', chunk => {
-        for (let i = 0; i < chunk.length; i++) {
-          charsSinceLineCount++;
-          if (chunk[i] === 10) {
-            lastLineEndIndex += charsSinceLineCount;
-            charsSinceLineCount = 0;
-            lineCount++;
-          }
+        const [lines, trailingChars] = formatChunk(chunk, unusedChars);
+        unusedChars = trailingChars;
+
+        if (historyLength > 0) {
+          history.push(...lines);
+          history = history.slice(Math.max(history.length - historyLength, 0));
         }
+
+        lineCount += lines.length;
+        endIndex += chunk.length;
       })
       .on('end', () => {
-        resolve([lineCount, lastLineEndIndex]);
+        endIndex = endIndex - unusedChars.length;
+        resolve([lineCount, endIndex, history]);
       })
       .on('error', err => {
         reject(err);
@@ -127,19 +129,6 @@ const readFile = filePath => {
       }
     });
   });
-};
-
-const readNthLines = async (filePath, lineNumber, numberOfLines) => {
-  let i;
-  let lines = {};
-  for (i = 0; i < numberOfLines; i++) {
-    lines[lineNumber + i] = await nthLine(lineNumber + i - 1, filePath);
-  }
-  if (lines !== null) {
-    return lines;
-  } else {
-    throw new Error('Lines are null.');
-  }
 };
 
 const getFileSizeInBytes = async filePath => {
@@ -182,10 +171,8 @@ const loadRecentFilesFromDisk = () => {
 module.exports = {
   readFile,
   readNLastLines,
-  getNumberOfLines,
-  readNthLines,
+  getLinesInfo,
   followFile,
-  fileReaderEvents,
   getFileSizeInBytes,
   stopWatcher,
   stopAllWatchers,

--- a/src/js/electron/menu.js
+++ b/src/js/electron/menu.js
@@ -151,7 +151,7 @@ const createMenu = () => {
     })
     .catch(err => {
       let action = {};
-      action.type = 'backendError';
+      action.type = 'error';
       action.data = err;
       webContents.send('backendMessages', action);
       Menu.setApplicationMenu(createTemplate());

--- a/src/js/electron/menu.js
+++ b/src/js/electron/menu.js
@@ -11,16 +11,15 @@ const handleMenuItemClicked = (type, data) => {
 };
 
 const handleShowOpenDialog = () => {
-  dialog.showOpenDialog(
-    {
-      properties: ['openFile']
-    },
-    filePath => {
-      if (filePath === undefined) return;
-      handleMenuItemClicked('open', filePath);
-      handleRecentFiles(filePath[0]);
-    }
-  );
+  const filePaths = dialog.showOpenDialog({
+    properties: ['openFile']
+  });
+
+  console.log(filePaths);
+
+  if (filePaths === undefined) return;
+  handleMenuItemClicked('open', filePaths);
+  handleRecentFiles(filePaths[0]);
 };
 
 const handleRecentFiles = filePath => {

--- a/src/js/electron/menu.js
+++ b/src/js/electron/menu.js
@@ -9,7 +9,7 @@ const handleShowOpenDialog = () => {
   ipcMain.emit(
     'frontendMessages',
     { sender: webContents },
-    { function: 'showOpenDialog' }
+    { function: 'DIALOG_OPEN_SHOW' }
   );
 };
 

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -21,7 +21,7 @@ const sendSourceOpened = (
   history
 ) => {
   const action = {
-    type: 'sourceOpened',
+    type: 'SOURCE_OPENED',
     filePath,
     numberOfLines,
     fileSize,
@@ -34,7 +34,7 @@ const sendSourceOpened = (
 const handleFollowSource = (sender, filePath) => {
   const onChange = lines => {
     const action = {
-      type: 'liveLines',
+      type: 'LINES_NEW',
       filePath,
       lines
     };
@@ -56,19 +56,19 @@ const loadStateFromDisk = sender => {
       }
 
       const action = {
-        type: 'loadState',
+        type: 'STATE_LOAD',
         data: _data
       };
 
       sender.send(ipcChannel, action);
     })
-    .catch(sendBackError(sender, "Couldn't load previous state from disk"));
+    .catch(sendError(sender, "Couldn't load previous state from disk"));
 };
 
-const sendBackError = (sender, message) => {
+const sendError = (sender, message) => {
   return err => {
     const action = {
-      type: 'error',
+      type: 'ERROR',
       message: message,
       error: err
     };
@@ -87,7 +87,7 @@ const loadRecentFilesFromDisk = () => {
 
 const openFile = async (sender, filePath) => {
   const fileInfo = await getFileInfo(filePath).catch(
-    sendBackError(sender, "Couldn't open file")
+    sendError(sender, "Couldn't open file")
   );
 
   if (!fileInfo) return;
@@ -113,20 +113,20 @@ const handleShowOpenDialog = async sender => {
 ipcMain.on('frontendMessages', async (event, _argObj) => {
   const sender = event.sender;
   switch (_argObj.function) {
-    case 'showOpenDialog':
+    case 'DIALOG_OPEN_SHOW':
       handleShowOpenDialog(sender);
       break;
-    case 'followSource':
+    case 'SOURCE_FOLLOW':
       fileReader.stopAllWatchers();
       handleFollowSource(sender, _argObj.filePath);
       break;
-    case 'unfollowSource':
+    case 'SOURCE_UNFOLLOW':
       fileReader.stopWatcher(_argObj);
       break;
-    case 'saveState':
+    case 'STATE_SAVE':
       fileReader.saveStateToDisk(_argObj.reduxStateValue);
       break;
-    case 'loadState':
+    case 'STATE_LOAD':
       loadStateFromDisk(sender);
       break;
     default:

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -56,7 +56,7 @@ const loadStateFromDisk = sender => {
       }
 
       const action = {
-        type: 'STATE_LOAD',
+        type: 'STATE_SET',
         data: _data
       };
 

--- a/src/js/view/App.js
+++ b/src/js/view/App.js
@@ -16,11 +16,11 @@ class App extends Component {
   render() {
     return (
       <RootContainer>
-        {this.props.source ? (
+        {this.props.openSources && this.props.openSources[0] ? (
           <LogPage>
             <TopPanel />
             <TabSettings />
-            <LogViewer source={this.props.source} />
+            <LogViewer source={this.props.openSources[0]} />
             <StatusBar />
             <SnackBar />
           </LogPage>
@@ -34,7 +34,7 @@ class App extends Component {
 
 const mapStateToProps = state => {
   return {
-    source: state.menuReducer.openSources[0]
+    openSources: state.menuReducer.openSources
   };
 };
 

--- a/src/js/view/App.js
+++ b/src/js/view/App.js
@@ -15,11 +15,11 @@ class App extends Component {
   render() {
     return (
       <RootContainer>
-        {this.props.openFiles && this.props.openFiles[0] ? (
+        {this.props.source ? (
           <LogPage>
             <TopPanel />
             <TabSettings />
-            <LogViewer />
+            <LogViewer source={this.props.source} />
             <Statusbar />
           </LogPage>
         ) : (
@@ -32,7 +32,7 @@ class App extends Component {
 
 const mapStateToProps = state => {
   return {
-    openFiles: state.menuReducer.openFiles
+    source: state.menuReducer.openSources[0]
   };
 };
 

--- a/src/js/view/App.js
+++ b/src/js/view/App.js
@@ -22,11 +22,11 @@ class App extends Component {
             <TabSettings />
             <LogViewer source={this.props.openSources[0]} />
             <StatusBar />
-            <SnackBar />
           </LogPage>
         ) : (
           <DefaultPage />
         )}
+        <SnackBar />
       </RootContainer>
     );
   }

--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -45,42 +45,44 @@ export const setLogSourceFile = (
   history
 ) => {
   dispatch({
-    type: 'setLogSource',
-    filePath
+    type: 'MENU_SET_SOURCE',
+    data: { filePath }
   });
 
   dispatch({
-    type: 'liveLines',
-    filePath,
-    lines: history
+    type: 'LOGVIEWER_ADD_LINES',
+    data: {
+      filePath,
+      lines: history
+    }
   });
 
   dispatch({
-    type: 'numberOfLines',
+    type: 'LOGINFO_SET_NUMBER_OF_LINES',
     data: numberOfLines
   });
 
   dispatch({
-    type: 'fileSize',
+    type: 'LOGINFO_SET_FILESIZE',
     data: fileSize
   });
 };
 
 export const clearSources = dispatch => {
   dispatch({
-    type: 'clearAllLogs'
+    type: 'LOGVIEWER_CLEAR'
   });
 
   dispatch({
-    type: 'nthLines',
+    type: 'MENU_CLEAR'
+  });
+
+  dispatch({
+    type: 'LOGINFO_SET_NUMBER_OF_LINES',
     data: ''
   });
   dispatch({
-    type: 'numberOfLines',
-    data: ''
-  });
-  dispatch({
-    type: 'fileSize',
+    type: 'LOGINFO_SET_FILESIZE',
     data: ''
   });
 };

--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -37,15 +37,40 @@ export const handleWrapLineOn = dispatch => {
   });
 };
 
-export const handleCloseFile = dispatch => {
+export const setLogSourceFile = (
+  dispatch,
+  filePath,
+  numberOfLines,
+  fileSize,
+  history
+) => {
   dispatch({
-    type: 'menu_open',
-    data: 'clearOpenFiles'
+    type: 'setLogSource',
+    filePath
   });
+
   dispatch({
-    type: 'clearLines',
-    data: ''
+    type: 'liveLines',
+    filePath,
+    lines: history
   });
+
+  dispatch({
+    type: 'numberOfLines',
+    data: numberOfLines
+  });
+
+  dispatch({
+    type: 'fileSize',
+    data: fileSize
+  });
+};
+
+export const clearSources = dispatch => {
+  dispatch({
+    type: 'clearAllLogs'
+  });
+
   dispatch({
     type: 'nthLines',
     data: ''

--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -37,7 +37,7 @@ export const handleWrapLineOn = dispatch => {
   });
 };
 
-export const setLogSourceFile = (
+export const setFileSource = (
   dispatch,
   filePath,
   numberOfLines,
@@ -46,14 +46,14 @@ export const setLogSourceFile = (
 ) => {
   dispatch({
     type: 'MENU_SET_SOURCE',
-    data: { filePath }
+    data: { sourcePath: filePath }
   });
 
   dispatch({
-    type: 'LOGVIEWER_ADD_LINES',
+    type: 'LOGVIEWER_SET_LOG',
     data: {
-      filePath,
-      lines: history
+      sourcePath: filePath,
+      log: history
     }
   });
 
@@ -65,6 +65,12 @@ export const setLogSourceFile = (
   dispatch({
     type: 'LOGINFO_SET_FILESIZE',
     data: fileSize
+  });
+};
+
+export const clearAllLogs = dispatch => {
+  dispatch({
+    type: 'LOGVIEWER_CLEAR'
   });
 };
 
@@ -92,6 +98,16 @@ export const hideSnackBar = (dispatch, instant) => {
     type: 'SNACKBAR_HIDE',
     data: {
       instant
+    }
+  });
+};
+
+export const addNewLines = (dispatch, sourcePath, lines) => {
+  dispatch({
+    type: 'LOGVIEWER_ADD_LINES',
+    data: {
+      sourcePath,
+      lines
     }
   });
 };

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -32,6 +32,7 @@ class LogViewer extends React.Component {
           }}
         />
         <LogViewerList
+          key={this.props.source}
           highlightColor={this.props.highlightColor}
           wrapLines={this.props.wrapLineOn}
           scrollToBottom={this.props.tailSwitch}
@@ -44,14 +45,18 @@ class LogViewer extends React.Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({
+  topPanelReducer,
+  settingsReducer,
+  logViewerReducer
+}) => {
   return {
-    filterInput: state.topPanelReducer.filterInput,
-    highlightInput: state.topPanelReducer.highlightInput,
-    highlightColor: state.settingsReducer.highlightColor,
-    wrapLineOn: state.settingsReducer.wrapLineOn,
-    logs: state.logViewerReducer.logs,
-    tailSwitch: state.topPanelReducer.tailSwitch
+    filterInput: topPanelReducer.filterInput,
+    highlightInput: topPanelReducer.highlightInput,
+    highlightColor: settingsReducer.highlightColor,
+    wrapLineOn: settingsReducer.wrapLineOn,
+    logs: logViewerReducer.logs,
+    tailSwitch: topPanelReducer.tailSwitch
   };
 };
 

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -24,6 +24,7 @@ class LogViewer extends React.Component {
     return (
       <LogViewerContainer>
         <CloseFileButton
+          show={this.props.source}
           onClick={() => {
             closeFile(
               this.props.dispatch,

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -17,6 +17,8 @@ class LogViewer extends React.Component {
   }
 
   render() {
+    const lines = this.props.logs[this.props.source];
+
     const highlightRegExp = parseRegExp(
       this.props.highlightInput,
       this.state.escapeRegexSequence
@@ -29,11 +31,10 @@ class LogViewer extends React.Component {
     return (
       <LogViewerContainer>
         <CloseFileButton
-          openFiles={this.props.openFiles}
           onClick={() => {
             closeFile(
               this.props.dispatch,
-              this.props.openFiles ? this.props.openFiles : ''
+              this.props.source ? this.props.source : ''
             );
           }}
         />
@@ -41,7 +42,7 @@ class LogViewer extends React.Component {
           highlightColor={this.props.highlightColor}
           wrapLines={this.props.wrapLineOn}
           scrollToBottom={this.props.tailSwitch}
-          lines={this.props.liveLines}
+          lines={lines ? lines : []}
           highlightRegExp={highlightRegExp}
           filterRegExp={filterRegExp}
         />
@@ -56,10 +57,8 @@ const mapStateToProps = state => {
     highlightInput: state.topPanelReducer.highlightInput,
     highlightColor: state.settingsReducer.highlightColor,
     wrapLineOn: state.settingsReducer.wrapLineOn,
-    liveLines: state.logViewerReducer.liveLines,
-    nthLines: state.logViewerReducer.nthLines,
-    tailSwitch: state.topPanelReducer.tailSwitch,
-    openFiles: state.menuReducer.openFiles
+    logs: state.logViewerReducer.logs,
+    tailSwitch: state.topPanelReducer.tailSwitch
   };
 };
 

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -110,6 +110,7 @@ class LogViewerList extends React.Component {
 
     //The line heights needs to be recalculated on a resize
     const charSize = calculateSize('W', this.rulerRef.current);
+    console.log(charSize);
     const clientWidth = this.logRef.current.clientWidth;
     const cachedLines = this.state.cachedLines;
     const cachedHeightsByLength = this.state.cachedHeightsByLength;

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -106,6 +106,8 @@ class LogViewerList extends React.Component {
 
   //The onResize function is debounced as the resize event occurs all the time while resizing the window
   onResize = _.debounce(() => {
+    if (!this.rulerRef.current) return;
+
     //The line heights needs to be recalculated on a resize
     const charSize = calculateSize('W', this.rulerRef.current);
     const clientWidth = this.logRef.current.clientWidth;

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -110,7 +110,6 @@ class LogViewerList extends React.Component {
 
     //The line heights needs to be recalculated on a resize
     const charSize = calculateSize('W', this.rulerRef.current);
-    console.log(charSize);
     const clientWidth = this.logRef.current.clientWidth;
     const cachedLines = this.state.cachedLines;
     const cachedHeightsByLength = this.state.cachedHeightsByLength;

--- a/src/js/view/components/SnackBar.js
+++ b/src/js/view/components/SnackBar.js
@@ -16,7 +16,9 @@ const SnackBar = props => {
       fadeAfter={props.fadeAfter}
     >
       <Layout row>
-        <Container grow>{props.message}</Container>
+        <Container grow pr-2>
+          {props.message}
+        </Container>
         <Container>
           <TextButton
             color="#bb86fc"

--- a/src/js/view/components/StatusBar.js
+++ b/src/js/view/components/StatusBar.js
@@ -27,10 +27,10 @@ class StatusBar extends React.Component {
 
         <ul>
           <ReactTooltip />
-          <li data-tip={this.props.openFiles[0]}>
+          <li data-tip={this.props.openSources[0]}>
             File:{' '}
-            {this.props.openFiles && this.props.openFiles[0]
-              ? getFormattedFilePath(this.props.openFiles[0])
+            {this.props.openSources && this.props.openSources[0]
+              ? getFormattedFilePath(this.props.openSources[0])
               : null}
           </li>
           <li>Lines:{this.props.numberOfLines}</li>
@@ -43,7 +43,7 @@ class StatusBar extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    openFiles: state.menuReducer.openFiles,
+    openSources: state.menuReducer.openSources,
     numberOfLines: state.logInfoReducer.numberOfLines,
     fileSize: state.logInfoReducer.fileSize
   };

--- a/src/js/view/components/helpers/errorHelper.js
+++ b/src/js/view/components/helpers/errorHelper.js
@@ -1,6 +1,7 @@
 import { getFormattedFilePath } from './StatusBarHelper';
 
 export const prettifyErrorMessage = (message, error) => {
+  console.log(error);
   switch (error.code) {
     case 'EACCES':
       return fileErrorMessage(message, error.path, 'permission denied');
@@ -8,6 +9,8 @@ export const prettifyErrorMessage = (message, error) => {
       return fileErrorMessage(message, error.path, 'is a directory');
     case 'ENOENT':
       return fileErrorMessage(message, error.path, 'does not exist');
+    case 'CUSTOM':
+      return `${message}, ${error.reason}`;
     default:
       return message;
   }

--- a/src/js/view/components/helpers/errorHelper.js
+++ b/src/js/view/components/helpers/errorHelper.js
@@ -1,0 +1,18 @@
+import { getFormattedFilePath } from './StatusBarHelper';
+
+export const prettifyErrorMessage = (message, error) => {
+  switch (error.code) {
+    case 'EACCES':
+      return fileErrorMessage(message, error.path, 'permission denied');
+    case 'EISDIR':
+      return fileErrorMessage(message, error.path, 'is a directory');
+    case 'ENOENT':
+      return fileErrorMessage(message, error.path, 'does not exist');
+    default:
+      return message;
+  }
+};
+
+const fileErrorMessage = (message, path, addendum) => {
+  return `${message} ${getFormattedFilePath(path)} ${addendum}`;
+};

--- a/src/js/view/components/helpers/handleFileHelper.js
+++ b/src/js/view/components/helpers/handleFileHelper.js
@@ -2,13 +2,13 @@ import { sendRequestToBackend } from 'js/view/ipcPublisher';
 import { clearSources } from '../../actions/dispatchActions';
 
 export const showOpenDialog = () => {
-  sendRequestToBackend({ function: 'showOpenDialog' });
+  sendRequestToBackend({ function: 'DIALOG_OPEN_SHOW' });
 };
 
 export const closeFile = (dispatch, _filePath) => {
   //send request to backend
   const argObj = {
-    function: 'unfollowSource',
+    function: 'SOURCE_UNFOLLOW',
     filePath: _filePath
   };
   sendRequestToBackend(argObj);

--- a/src/js/view/components/helpers/handleFileHelper.js
+++ b/src/js/view/components/helpers/handleFileHelper.js
@@ -1,19 +1,18 @@
-import { sendRequestToBackend } from '../../ipcPublisher';
-import { handleCloseFile } from '../../actions/dispatchActions';
-
-let argObj = {};
+import { sendRequestToBackend } from 'js/view/ipcPublisher';
+import { clearSources } from '../../actions/dispatchActions';
 
 export const showOpenDialog = () => {
-  argObj.function = 'showOpenDialog';
-  sendRequestToBackend(argObj);
+  sendRequestToBackend({ function: 'showOpenDialog' });
 };
 
 export const closeFile = (dispatch, _filePath) => {
   //send request to backend
-  argObj.function = 'stopWatcher';
-  argObj.filePath = _filePath;
+  const argObj = {
+    function: 'unfollowSource',
+    filePath: _filePath
+  };
   sendRequestToBackend(argObj);
 
   //handle related states on frontend
-  handleCloseFile(dispatch);
+  clearSources(dispatch);
 };

--- a/src/js/view/configurations/configureStore.js
+++ b/src/js/view/configurations/configureStore.js
@@ -6,13 +6,13 @@ export const configureStore = (store, send = sendRequestToBackend) => {
     delete _state.logInfoReducer;
     delete _state.logViewerReducer;
     send({
-      function: 'saveState',
+      function: 'STATE_SAVE',
       reduxStateValue: JSON.stringify(_state)
     });
   };
 
   const loadStateFromDisk = () => {
-    send({ function: 'loadState' });
+    send({ function: 'STATE_LOAD' });
   };
 
   const populateStore = _savedStates => {
@@ -21,33 +21,12 @@ export const configureStore = (store, send = sendRequestToBackend) => {
         type: `${_reducer[0]}Restore`,
         data: _reducer[1]
       });
-      if (_reducer[0] === 'menuReducer') {
-        initializeOpenFile(_reducer[1].openFiles[0]);
-      }
     });
-  };
-
-  const initializeOpenFile = filePath => {
-    const args = {
-      filePath,
-      numberOfLines: 5,
-      lineNumber: 10
-    };
-    send({
-      ...args,
-      function: 'liveLines'
-    });
-    send({
-      ...args,
-      function: 'numberOfLines'
-    });
-    send({ ...args, function: 'fileSize' });
   };
 
   return {
     saveStateToDisk,
     loadStateFromDisk,
-    populateStore,
-    initializeOpenFile
+    populateStore
   };
 };

--- a/src/js/view/configurations/configureStore.test.js
+++ b/src/js/view/configurations/configureStore.test.js
@@ -17,7 +17,7 @@ it('should saveStateToDisk', () => {
   expect(fakeRequester.mock.calls.length).toBe(1);
   expect(fakeRequester.mock.calls[0]).toEqual([
     {
-      function: 'saveState',
+      function: 'STATE_SAVE',
       reduxStateValue: '{"testStuff":"two"}'
     }
   ]);

--- a/src/js/view/ipcListener.js
+++ b/src/js/view/ipcListener.js
@@ -14,7 +14,7 @@ const handleSourceOpened = (
   setLogSourceFile(dispatch, filePath, numberOfLines, fileSize, history);
 
   const followSource = {
-    function: 'followSource',
+    function: 'SOURCE_FOLLOW',
     filePath
   };
 
@@ -42,25 +42,27 @@ const handleError = (dispatch, { message, error }) => {
 export const ipcListener = (store, publisher) => {
   const dispatch = store.dispatch;
 
-  ipcRenderer.on('backendMessages', (event, action) => {
+  ipcRenderer.on('backendMessages', (_event, action) => {
     switch (action.type) {
-      case 'saveState':
+      case 'STATE_SAVE':
         publisher.saveStateToDisk();
         break;
-      case 'loadState':
+      case 'STATE_LOAD':
         publisher.populateStore(JSON.parse(action.data));
         break;
-      case 'sourceOpened':
+      case 'SOURCE_OPENED':
         handleSourceOpened(dispatch, action);
         break;
-      case 'error':
+      case 'ERROR':
         handleError(dispatch, action);
         break;
-      case 'liveLines':
+      case 'LINES_NEW':
         dispatch({
-          type: 'liveLines',
-          filePath: action.filePath,
-          lines: action.lines
+          type: 'LOGVIEWER_ADD_LINES',
+          data: {
+            filePath: action.filePath,
+            lines: action.lines
+          }
         });
         break;
       default:

--- a/src/js/view/ipcListener.js
+++ b/src/js/view/ipcListener.js
@@ -44,10 +44,10 @@ export const ipcListener = (store, publisher) => {
 
   ipcRenderer.on('backendMessages', (_event, action) => {
     switch (action.type) {
-      case 'STATE_SAVE':
+      case 'QUIT':
         publisher.saveStateToDisk();
         break;
-      case 'STATE_LOAD':
+      case 'STATE_SET':
         publisher.populateStore(JSON.parse(action.data));
         break;
       case 'SOURCE_OPENED':

--- a/src/js/view/ipcListener.js
+++ b/src/js/view/ipcListener.js
@@ -11,7 +11,6 @@ const { ipcRenderer } = window.require('electron');
 const handleSourceOpened = (dispatch, { sourceType, ...rest }) => {
   switch (sourceType) {
     case 'FILE':
-      console.log(rest);
       handleFileOpened(dispatch, rest);
       break;
     default:
@@ -21,7 +20,7 @@ const handleSourceOpened = (dispatch, { sourceType, ...rest }) => {
 
 const handleFileOpened = (
   dispatch,
-  { filePath, lineCount, lastLineEndIndex, fileSize, history }
+  { filePath, lineCount, endIndex, fileSize, history }
 ) => {
   clearAllLogs(dispatch);
   setFileSource(dispatch, filePath, lineCount, fileSize, history);
@@ -31,7 +30,7 @@ const handleFileOpened = (
     data: {
       sourceType: 'FILE',
       filePath,
-      fromIndex: lastLineEndIndex
+      fromIndex: endIndex
     }
   };
   sendRequestToBackend(followSource);

--- a/src/js/view/ipcListener.js
+++ b/src/js/view/ipcListener.js
@@ -11,10 +11,11 @@ const { ipcRenderer } = window.require('electron');
 const handleSourceOpened = (dispatch, { sourceType, ...rest }) => {
   switch (sourceType) {
     case 'FILE':
+      console.log(rest);
       handleFileOpened(dispatch, rest);
       break;
     default:
-      console.log('Unknown source type');
+      console.log('ipcListener.js: Unknown source type');
   }
 };
 

--- a/src/js/view/ipcListener.js
+++ b/src/js/view/ipcListener.js
@@ -23,10 +23,8 @@ export const ipcListener = (store, publisher) => {
       case 'loadState':
         publisher.populateStore(JSON.parse(action.data));
         break;
-      case 'backendError':
-        //handle errors in the future
-        // alert('Error occured. ', action.data);
-        console.log('Error from the backend: ', action.data);
+      case 'error':
+        console.log('Error: ', action.message, ', ', action.error);
         break;
       default:
         dispatch({

--- a/src/js/view/reducers/logInfoReducer.js
+++ b/src/js/view/reducers/logInfoReducer.js
@@ -2,12 +2,12 @@ const initialState = { numberOfLines: 0, fileSize: 0 };
 
 export const logInfoReducer = (state = initialState, action) => {
   switch (action.type) {
-    case 'numberOfLines':
+    case 'LOGINFO_SET_NUMBER_OF_LINES':
       return {
         ...state,
         numberOfLines: action.data
       };
-    case 'fileSize':
+    case 'LOGINFO_SET_FILESIZE':
       return {
         ...state,
         fileSize: action.data

--- a/src/js/view/reducers/logInfoReducer.js
+++ b/src/js/view/reducers/logInfoReducer.js
@@ -1,4 +1,6 @@
-export const logInfoReducer = (state = {}, action) => {
+const initialState = { numberOfLines: 0, fileSize: 0 };
+
+export const logInfoReducer = (state = initialState, action) => {
   switch (action.type) {
     case 'numberOfLines':
       return {

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -1,16 +1,20 @@
-const initialState = { liveLines: [] };
+const initialState = { logs: {} };
+
 export const logViewerReducer = (state = initialState, action) => {
   switch (action.type) {
-    case 'clearLines':
+    case 'clearAllLogs':
       return {
         ...state,
-        liveLines: []
+        logs: {}
       };
     case 'liveLines':
-      return {
-        ...state,
-        liveLines: [...state.liveLines, ...action.data.split('\n')]
-      };
+      const newLines = action.lines.split(/\r?\n/);
+      const newLogs = { ...state.logs };
+      const oldLog = state.logs[action.filePath];
+      newLogs[action.filePath] = oldLog ? [...oldLog, ...newLines] : newLines;
+
+      return { ...state, logs: newLogs };
+
     default:
       return state;
   }

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -1,5 +1,11 @@
 const initialState = { logs: {} };
 
+const formatLines = lines => {
+  return lines.split(/\r?\n/).filter(x => {
+    return x;
+  });
+};
+
 export const logViewerReducer = (state = initialState, action) => {
   switch (action.type) {
     case 'LOGVIEWER_CLEAR':
@@ -10,13 +16,13 @@ export const logViewerReducer = (state = initialState, action) => {
     case 'LOGVIEWER_SET_LOG': {
       const { sourcePath, log } = action.data;
       const newLogs = { ...state.logs };
-      newLogs[sourcePath] = log.split(/\r?\n/);
+      newLogs[sourcePath] = formatLines(log);
 
       return { ...state, logs: newLogs };
     }
     case 'LOGVIEWER_ADD_LINES':
       const { sourcePath, lines } = action.data;
-      const newLines = lines.split(/\r?\n/);
+      const newLines = formatLines(lines);
       const newLogs = { ...state.logs };
       const oldLog = state.logs[sourcePath];
       newLogs[sourcePath] = oldLog ? [...oldLog, ...newLines] : newLines;

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -7,20 +7,23 @@ export const logViewerReducer = (state = initialState, action) => {
         ...state,
         logs: {}
       };
+    case 'LOGVIEWER_SET_LOG': {
+      const { sourcePath, log } = action.data;
+      const newLogs = { ...state.logs };
+      newLogs[sourcePath] = log.split(/\r?\n/);
+
+      return { ...state, logs: newLogs };
+    }
     case 'LOGVIEWER_ADD_LINES':
-      const { filePath, lines } = action.data;
+      const { sourcePath, lines } = action.data;
       const newLines = lines.split(/\r?\n/);
       const newLogs = { ...state.logs };
-      const oldLog = state.logs[filePath];
-      newLogs[filePath] = oldLog ? [...oldLog, ...newLines] : newLines;
+      const oldLog = state.logs[sourcePath];
+      newLogs[sourcePath] = oldLog ? [...oldLog, ...newLines] : newLines;
 
       return { ...state, logs: newLogs };
 
     default:
       return state;
   }
-};
-
-const getLog = (state, name) => {
-  return state.logs[name];
 };

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -1,11 +1,5 @@
 const initialState = { logs: {} };
 
-const formatLines = lines => {
-  return lines.split(/\r?\n/).filter(x => {
-    return x;
-  });
-};
-
 export const logViewerReducer = (state = initialState, action) => {
   switch (action.type) {
     case 'LOGVIEWER_CLEAR':
@@ -15,17 +9,16 @@ export const logViewerReducer = (state = initialState, action) => {
       };
     case 'LOGVIEWER_SET_LOG': {
       const { sourcePath, log } = action.data;
-      const newLogs = { ...state.logs };
-      newLogs[sourcePath] = formatLines(log);
+      const logs = { ...state.logs };
+      logs[sourcePath] = [...log];
 
-      return { ...state, logs: newLogs };
+      return { ...state, logs: logs };
     }
     case 'LOGVIEWER_ADD_LINES':
       const { sourcePath, lines } = action.data;
-      const newLines = formatLines(lines);
       const newLogs = { ...state.logs };
-      const oldLog = state.logs[sourcePath];
-      newLogs[sourcePath] = oldLog ? [...oldLog, ...newLines] : newLines;
+      const log = state.logs[sourcePath];
+      newLogs[sourcePath] = log ? [...log, ...lines] : [...lines];
 
       return { ...state, logs: newLogs };
 

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -2,20 +2,25 @@ const initialState = { logs: {} };
 
 export const logViewerReducer = (state = initialState, action) => {
   switch (action.type) {
-    case 'clearAllLogs':
+    case 'LOGVIEWER_CLEAR':
       return {
         ...state,
         logs: {}
       };
-    case 'liveLines':
-      const newLines = action.lines.split(/\r?\n/);
+    case 'LOGVIEWER_ADD_LINES':
+      const { filePath, lines } = action.data;
+      const newLines = lines.split(/\r?\n/);
       const newLogs = { ...state.logs };
-      const oldLog = state.logs[action.filePath];
-      newLogs[action.filePath] = oldLog ? [...oldLog, ...newLines] : newLines;
+      const oldLog = state.logs[filePath];
+      newLogs[filePath] = oldLog ? [...oldLog, ...newLines] : newLines;
 
       return { ...state, logs: newLogs };
 
     default:
       return state;
   }
+};
+
+const getLog = (state, name) => {
+  return state.logs[name];
 };

--- a/src/js/view/reducers/logViewerReducer.test.js
+++ b/src/js/view/reducers/logViewerReducer.test.js
@@ -14,7 +14,7 @@ describe('logviewer reducer', () => {
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });
   it('should append lines to initial state', () => {
-    const lines = 'hej1\nhej2\nhej3\n';
+    const lines = ['hej1', 'hej2', 'hej3'];
     const expectedState = {
       logs: { test: ['hej1', 'hej2', 'hej3'] }
     };
@@ -30,7 +30,7 @@ describe('logviewer reducer', () => {
     expect(logViewerReducer(undefined, action)).toEqual(expectedState);
   });
   it('should set log on source', () => {
-    const log = 'hej4\nhej5\n';
+    const log = ['hej4', 'hej5'];
     const state = {
       logs: { test: ['hej1', 'hej2', 'hej3'] }
     };
@@ -45,7 +45,7 @@ describe('logviewer reducer', () => {
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });
   it('should append lines to source', () => {
-    const lines = 'hej4\nhej5\n';
+    const lines = ['hej4', 'hej5'];
     const state = {
       logs: { test: ['hej1', 'hej2', 'hej3'] }
     };

--- a/src/js/view/reducers/logViewerReducer.test.js
+++ b/src/js/view/reducers/logViewerReducer.test.js
@@ -1,6 +1,6 @@
 import { logViewerReducer } from './logViewerReducer';
 
-describe('logViewer reducers', () => {
+describe('logviewer reducer', () => {
   it('should return the initial state', () => {
     const initialState = { logs: {} };
     expect(logViewerReducer(undefined, {})).toEqual(initialState);
@@ -18,18 +18,33 @@ describe('logViewer reducers', () => {
     const expectedState = {
       logs: { test: ['hej1', 'hej2', 'hej3', ''] }
     };
-    const filePath = 'test';
+    const sourcePath = 'test';
 
     const action = {
       type: 'LOGVIEWER_ADD_LINES',
       data: {
-        filePath,
+        sourcePath,
         lines
       }
     };
     expect(logViewerReducer(undefined, action)).toEqual(expectedState);
   });
-  it('should append lines to populated state', () => {
+  it('should set log on source', () => {
+    const log = 'hej4\nhej5\n';
+    const state = {
+      logs: { test: ['hej1', 'hej2', 'hej3', ''] }
+    };
+    const expectedState = {
+      logs: { test: ['hej4', 'hej5', ''] }
+    };
+    const sourcePath = 'test';
+    const action = {
+      type: 'LOGVIEWER_SET_LOG',
+      data: { sourcePath, log }
+    };
+    expect(logViewerReducer(state, action)).toEqual(expectedState);
+  });
+  it('should append lines to source', () => {
     const lines = 'hej4\nhej5\n';
     const state = {
       logs: { test: ['hej1', 'hej2', 'hej3', ''] }
@@ -37,10 +52,10 @@ describe('logViewer reducers', () => {
     const expectedState = {
       logs: { test: ['hej1', 'hej2', 'hej3', '', 'hej4', 'hej5', ''] }
     };
-    const filePath = 'test';
+    const sourcePath = 'test';
     const action = {
       type: 'LOGVIEWER_ADD_LINES',
-      data: { filePath, lines }
+      data: { sourcePath, lines }
     };
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });

--- a/src/js/view/reducers/logViewerReducer.test.js
+++ b/src/js/view/reducers/logViewerReducer.test.js
@@ -16,7 +16,7 @@ describe('logviewer reducer', () => {
   it('should append lines to initial state', () => {
     const lines = 'hej1\nhej2\nhej3\n';
     const expectedState = {
-      logs: { test: ['hej1', 'hej2', 'hej3', ''] }
+      logs: { test: ['hej1', 'hej2', 'hej3'] }
     };
     const sourcePath = 'test';
 
@@ -32,10 +32,10 @@ describe('logviewer reducer', () => {
   it('should set log on source', () => {
     const log = 'hej4\nhej5\n';
     const state = {
-      logs: { test: ['hej1', 'hej2', 'hej3', ''] }
+      logs: { test: ['hej1', 'hej2', 'hej3'] }
     };
     const expectedState = {
-      logs: { test: ['hej4', 'hej5', ''] }
+      logs: { test: ['hej4', 'hej5'] }
     };
     const sourcePath = 'test';
     const action = {
@@ -47,10 +47,10 @@ describe('logviewer reducer', () => {
   it('should append lines to source', () => {
     const lines = 'hej4\nhej5\n';
     const state = {
-      logs: { test: ['hej1', 'hej2', 'hej3', ''] }
+      logs: { test: ['hej1', 'hej2', 'hej3'] }
     };
     const expectedState = {
-      logs: { test: ['hej1', 'hej2', 'hej3', '', 'hej4', 'hej5', ''] }
+      logs: { test: ['hej1', 'hej2', 'hej3', 'hej4', 'hej5'] }
     };
     const sourcePath = 'test';
     const action = {

--- a/src/js/view/reducers/logViewerReducer.test.js
+++ b/src/js/view/reducers/logViewerReducer.test.js
@@ -2,39 +2,44 @@ import { logViewerReducer } from './logViewerReducer';
 
 describe('logViewer reducers', () => {
   it('should return the initial state', () => {
-    const initialState = { liveLines: [] };
+    const initialState = { logs: {} };
     expect(logViewerReducer(undefined, {})).toEqual(initialState);
   });
   it('should reset lines', () => {
-    const state = { liveLines: ['lalala', 'lililil'] };
-    const expectedState = { liveLines: [] };
+    const state = { logs: ['lalala', 'lililil'] };
+    const expectedState = { logs: {} };
     const action = {
-      type: 'clearLines'
+      type: 'clearAllLogs'
     };
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });
   it('should append lines to initial state', () => {
     const lines = 'hej1\nhej2\nhej3\n';
     const expectedState = {
-      liveLines: ['hej1', 'hej2', 'hej3', '']
+      logs: { test: ['hej1', 'hej2', 'hej3', ''] }
     };
+    const filePath = 'test';
+
     const action = {
       type: 'liveLines',
-      data: lines
+      filePath,
+      lines
     };
     expect(logViewerReducer(undefined, action)).toEqual(expectedState);
   });
   it('should append lines to populated state', () => {
     const lines = 'hej4\nhej5\n';
     const state = {
-      liveLines: ['hej1', 'hej2', 'hej3', '']
+      logs: { test: ['hej1', 'hej2', 'hej3', ''] }
     };
     const expectedState = {
-      liveLines: ['hej1', 'hej2', 'hej3', '', 'hej4', 'hej5', '']
+      logs: { test: ['hej1', 'hej2', 'hej3', '', 'hej4', 'hej5', ''] }
     };
+    const filePath = 'test';
     const action = {
       type: 'liveLines',
-      data: lines
+      filePath,
+      lines
     };
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });

--- a/src/js/view/reducers/logViewerReducer.test.js
+++ b/src/js/view/reducers/logViewerReducer.test.js
@@ -9,7 +9,7 @@ describe('logViewer reducers', () => {
     const state = { logs: ['lalala', 'lililil'] };
     const expectedState = { logs: {} };
     const action = {
-      type: 'clearAllLogs'
+      type: 'LOGVIEWER_CLEAR'
     };
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });
@@ -21,9 +21,11 @@ describe('logViewer reducers', () => {
     const filePath = 'test';
 
     const action = {
-      type: 'liveLines',
-      filePath,
-      lines
+      type: 'LOGVIEWER_ADD_LINES',
+      data: {
+        filePath,
+        lines
+      }
     };
     expect(logViewerReducer(undefined, action)).toEqual(expectedState);
   });
@@ -37,9 +39,8 @@ describe('logViewer reducers', () => {
     };
     const filePath = 'test';
     const action = {
-      type: 'liveLines',
-      filePath,
-      lines
+      type: 'LOGVIEWER_ADD_LINES',
+      data: { filePath, lines }
     };
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });

--- a/src/js/view/reducers/logViewerReducer.test.js
+++ b/src/js/view/reducers/logViewerReducer.test.js
@@ -5,7 +5,7 @@ describe('logViewer reducers', () => {
     const initialState = { logs: {} };
     expect(logViewerReducer(undefined, {})).toEqual(initialState);
   });
-  it('should reset lines', () => {
+  it('should reset all logs', () => {
     const state = { logs: ['lalala', 'lililil'] };
     const expectedState = { logs: {} };
     const action = {

--- a/src/js/view/reducers/menuReducer.js
+++ b/src/js/view/reducers/menuReducer.js
@@ -1,17 +1,14 @@
-export const menuReducer = (state = {}, action) => {
+const initialState = { openSources: [] };
+
+export const menuReducer = (state = initialState, action) => {
   switch (action.type) {
-    case 'menu_open':
-      return {
-        ...state,
-        openFiles:
-          action.data !== 'clearOpenFiles'
-            ? state.openFiles
-              ? [...state.openFiles, action.data[0]]
-              : [action.data[0]]
-            : []
-      };
+    case 'clearAllLogs':
+      return { ...state, openSources: [] };
+
+    case 'setLogSource':
+      return { ...state, openSources: [action.filePath] };
     case 'menuReducerRestore':
-      return { ...action.data };
+      return { ...initialState, ...action.data };
     default:
       return state;
   }

--- a/src/js/view/reducers/menuReducer.js
+++ b/src/js/view/reducers/menuReducer.js
@@ -6,8 +6,8 @@ export const menuReducer = (state = initialState, action) => {
       return { ...state, openSources: [] };
 
     case 'MENU_SET_SOURCE':
-      const { filePath } = action.data;
-      return { ...state, openSources: [filePath] };
+      const { sourcePath } = action.data;
+      return { ...state, openSources: [sourcePath] };
     case 'menuReducerRestore':
       return { ...initialState, ...action.data };
     default:

--- a/src/js/view/reducers/menuReducer.js
+++ b/src/js/view/reducers/menuReducer.js
@@ -2,11 +2,12 @@ const initialState = { openSources: [] };
 
 export const menuReducer = (state = initialState, action) => {
   switch (action.type) {
-    case 'clearAllLogs':
+    case 'MENU_CLEAR':
       return { ...state, openSources: [] };
 
-    case 'setLogSource':
-      return { ...state, openSources: [action.filePath] };
+    case 'MENU_SET_SOURCE':
+      const { filePath } = action.data;
+      return { ...state, openSources: [filePath] };
     case 'menuReducerRestore':
       return { ...initialState, ...action.data };
     default:

--- a/src/js/view/reducers/menuReducer.test.js
+++ b/src/js/view/reducers/menuReducer.test.js
@@ -9,7 +9,7 @@ it('should return state at unknown type', () => {
 it('should set openSources to specified file', () => {
   const filePath = 'hey/ho/lets.go';
   const state = {};
-  const action = { type: 'MENU_SET_SOURCE', data: { filePath } };
+  const action = { type: 'MENU_SET_SOURCE', data: { sourcePath: filePath } };
   const expectedState = { openSources: [filePath] };
   expect(menuReducer(state, action)).toEqual(expectedState);
 });

--- a/src/js/view/reducers/menuReducer.test.js
+++ b/src/js/view/reducers/menuReducer.test.js
@@ -9,7 +9,7 @@ it('should return state at unknown type', () => {
 it('should set openSources to specified file', () => {
   const filePath = 'hey/ho/lets.go';
   const state = {};
-  const action = { type: 'setLogSource', filePath: filePath };
+  const action = { type: 'MENU_SET_SOURCE', data: { filePath } };
   const expectedState = { openSources: [filePath] };
   expect(menuReducer(state, action)).toEqual(expectedState);
 });

--- a/src/js/view/reducers/menuReducer.test.js
+++ b/src/js/view/reducers/menuReducer.test.js
@@ -6,19 +6,10 @@ it('should return state at unknown type', () => {
   expect(menuReducer(state, action)).toEqual(state);
 });
 
-it('should add file to openFiles', () => {
-  const theFilePath = 'hey/ho/lets.go';
+it('should set openSources to specified file', () => {
+  const filePath = 'hey/ho/lets.go';
   const state = {};
-  const action = { type: 'menu_open', data: [theFilePath] };
-  const expectedState = { openFiles: [theFilePath] };
-  expect(menuReducer(state, action)).toEqual(expectedState);
-});
-
-it('should add more files to openFiles', () => {
-  const initialFilePath = 'one/two/three.four';
-  const theFilePath = 'hey/ho/lets.go';
-  const state = { openFiles: [initialFilePath] };
-  const action = { type: 'menu_open', data: [theFilePath] };
-  const expectedState = { openFiles: [initialFilePath, theFilePath] };
+  const action = { type: 'setLogSource', filePath: filePath };
+  const expectedState = { openSources: [filePath] };
   expect(menuReducer(state, action)).toEqual(expectedState);
 });

--- a/src/js/view/styledComponents/LogViewerStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerStyledComponents.js
@@ -16,7 +16,7 @@ export const CloseFileButton = styled.button`
   margin-top: 10px;
   margin-left: calc(100% - 52px);
   display: ${props => {
-    return props.openFiles && props.openFiles[0] ? 'block' : 'none';
+    return props.show ? 'block' : 'none';
   }};
   box-sizing: border-box;
   width: 27px;

--- a/src/js/view/styledComponents/common/FlexBoxStyledComponents.js
+++ b/src/js/view/styledComponents/common/FlexBoxStyledComponents.js
@@ -17,8 +17,46 @@ export const Layout = styled.div`
   }};
 `;
 
+const calculatePadding = level => {
+  if (level <= 0) return 0;
+  return 3 * Math.pow(2, level);
+};
+
+const findLevel = (props, prefix) => {
+  let prop = Object.keys(props).find(x => {
+    return x.startsWith(prefix);
+  });
+  if (!prop) return 0;
+
+  return Number.parseInt(prop.slice(prefix.length));
+};
+
 export const Container = styled.div`
   display: flex;
+
+  ${props => {
+    let padding = [
+      findLevel(props, 'pt-'),
+      findLevel(props, 'pr-'),
+      findLevel(props, 'pb-'),
+      findLevel(props, 'pl-')
+    ]
+      .map((x, i) => {
+        return (
+          findLevel(props, 'pa-') ||
+          (i & 1 && findLevel(props, 'px-')) ||
+          (!(i & 1) && findLevel(props, 'py-')) ||
+          x
+        );
+      })
+      .map(x => {
+        return calculatePadding(x);
+      });
+
+    return `padding: ${padding[0]}px ${padding[1]}px ${padding[2]}px ${
+      padding[3]
+    }px`;
+  }}
   flex-direction: ${props => {
     return props.column ? 'column' : 'row';
   }};


### PR DESCRIPTION
This pull request will make it so that error messages show up as notifications in the frontend, but also change part of the structure of the backend.

Instead of passing a message to the frontend, and then back when opening a file, the file is opened in the backend and then the frontend is told that a file is opened. Then the frontend sends back a message to follow the file when done.

The gathering of file information (number of lines, end index and history) is now happening in one pass and splits on \r and \n. The lines are also sent as an array of strings than a string, that was split in the logViewer.

This pull request also contains some common styled components for using flexboxes.

As we only support one file at the moment opening a file has the special behaviour of closing watchers to  other files right now. Made it so that logs are stored based on their filepath in log viewer. 


