### PR TITLE
#304 Fix bug with the first row in a file not being added to the last N lines

### DIFF
--- a/src/js/adapters/fileReader.js
+++ b/src/js/adapters/fileReader.js
@@ -167,7 +167,7 @@ const readNLastLines = (filePath, numberOfLines, endIndex) => {
         }
       })
       .on('end', () => {
-        if (result.length < numberOfLines) {
+        if (result.length < numberOfLines && unusedChars) {
           result.unshift(unusedChars);
         }
 

--- a/src/js/adapters/fileReader.js
+++ b/src/js/adapters/fileReader.js
@@ -167,6 +167,10 @@ const readNLastLines = (filePath, numberOfLines, endIndex) => {
         }
       })
       .on('end', () => {
+        if (result.length < numberOfLines) {
+          result.unshift(unusedChars);
+        }
+
         resolve(result);
       })
       .on('error', err => {


### PR DESCRIPTION
There was a bug that if you had a file that was less than ten rows then the first row wasn't being read

This was caused by not adding all the unused characters if we hit the start of the file.
