### PR TITLE
#299 Make it so that when wrapped the x-scrollbar is hidden

### DIFF
--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -165,7 +165,10 @@ class LogViewerList extends React.Component {
       : this.noWrapItemSizeGetter(this.state.cachedCharSize[0]);
 
     return (
-      <LogViewerListContainer ref={this.logRef}>
+      <LogViewerListContainer
+        ref={this.logRef}
+        wrap={wrapLines ? 'true' : undefined}
+      >
         <LogLineRuler ref={this.rulerRef} />
         <WindowedList
           ref={this.windowedListRef}

--- a/src/js/view/styledComponents/LogViewerListStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerListStyledComponents.js
@@ -3,7 +3,10 @@ import Color from 'color';
 
 export const LogViewerListContainer = styled.div`
   min-width: 100%;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: ${props => {
+    return props.wrap ? 'hidden' : 'auto';
+  }};
 `;
 
 export const LogLine = styled.div`


### PR DESCRIPTION
This pull request will hide the x-axis scrollbar when wrapping lines. This will make it so the scrollbar doesn't show up on Windows, or any other platform as that is the intended behaviour when wrapping lines.