### PR TITLE
Hotfix for multiple files and hidden window offloader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ deploy:
   provider: releases
   api_key:
     secure: hHEJcTGLLjtbk1foVHkn/u7JBl1N9x/TwkMq5fX8JVWCRdcXL06NZnwbt8vb/Ah7CLgvXvGrn77aU0qWlbtj8d+MBo7oTW/dgGzT7PyXKhq4uj+E6KYFcmjCJv3tSHxy4H3U304IRuXYQGhzKZceuvVUSKUReKUz64ICDwJvPnU57tYo1jLKv8T5ZQTgQZvd8roAhxhLKND/gatayr+4Jdyzr/LAwx3jeweWNFFOaBkgiwSov6cuf4GVQ9zk5SwqnKdNiTQp5h1mRbYLqem6qIyEgU7X3g8rVff4LumqqyL9jpqjAf0ppujgFL8dZ6ktAkIWo7/8DpA7Jfkf0MNg6e0FVos6r7/EWdgu3/OPRCTn6bSHznv15jpxclSzIV5uXjrcGXUgljm8oAUfyUQTYSn9xKMv+cgvO0OtmjfYE7hgNwt3odtcUp0jeKi4NJvuzDVaC+56QCFbx+bgkTUfS1ypmV6u3f5eNyDtd5mIPaE11pBXQP2CoKXvxFqLNodjxSe5vTB9cqeaHMmYgSYvhfD6jfvV77LFIyB+RjQfnbq9JZXMiZlhjFn6cNkUfK58oHxCpGTeMQ4qBekCbN7syWMJqNSUTjHbc+sZncexwPnMAg8gCmLCeY26bitXDAauiizm13Gof337AG52w88tzAOkqFpa1gOR+T8wyOnbqEs=
-  file_glob: true
-  file: dist/*
+  file:
+    - 'dist/loglady-1.1.1.AppImage'
+    - 'dist/loglady-1.1.1.dmg'
+    - 'dist/loglady Setup 1.1.1.exe'
   skip_cleanup: true
   on:
     branch: master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loglady",
-  "version": "v1.1.0",
+  "version": "v1.1.1",
   "description": "Log file viewer",
   "author": "lalala",
   "homepage": "./",


### PR DESCRIPTION
I have identified what caused the problem that no new lines would be added and different tabs would show the same lines.

It was because I was using a stale props in my eventlistener, and making sure the source matched the one that was sent. I did this in preparation for multiple files as I thought there would be one LogViewer component for each open file - but that isn't the case currently.
In the future, when we try to have multiple tabs split in the window, this solution probably won't work - but that's what makes it a hotfix I guess 🤷‍♂

I tested it on my machine and it works as expected. Please try opening multiple files and adding lines to them on your end as well!