### PR TITLE
Hotfix for duplicate lines while filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "loglady",
-  "version": "v1.1.0",
+  "version": "v1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -59,6 +59,8 @@ const LogViewer = props => {
     /* Effect for when a new filter or highlight is applied,
     send the lines to be filtered and highlighted again */
     if (props.logs[props.source.path]) {
+      // Reset the previous lines count, as all lines should be wiped.
+      previousLinesLength.current = 0;
       sendMessageToHiddenWindow({
         logs: props.logs[props.source.path]
       });


### PR DESCRIPTION
I have identified what caused the problem that sometimes duplicate lines would show up when a filter was set. I missed this while testing the filtering earlier.

The problem happens because I was using the state to determine what lines were new in order to only send those in the hook for when props.logs changes - but updating state happens asynchronously, so the state can't be relied on like that.

I fixed the problem by using a ref to keep track of the length of props.logs last time the hook was called. Ref is mutable, so I can rely on it to be correct for every call of the hook, and I update it using props.logs which the hook depends on to be fired. The ref is reset when a filter or highlight is changed, as the current logs will be wiped by that.

I also noticed that the version in package-lock.json and in package.json was out of sync, so I ran `npm install` and committed the changes to package-lock.json. I should have done this in PR #339.