### PR TITLE
#353 Update links for website

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,6 +167,72 @@
         }
       }
     </style>
+    <script>
+      const determineUserOS = () => {
+        if (navigator.platform.startsWith("Mac")) {
+          return "Mac";
+        }
+        if (navigator.platform.startsWith("Linux")) {
+          return "Linux";
+        }
+        if (navigator.platform.startsWith("Win")) {
+          return "Windows";
+        }
+      };
+      window.onload = () => {
+        let downloadButton = document.querySelector("button.download-btn"),
+          downloadLink = "https://github.com/kits-ab/LogLady/releases/latest"; // Default state, link to the latest release on GitHub
+
+        downloadButton.onclick = () => {
+          location.href = downloadLink;
+        };
+
+        // Fetch information on the latest release using GitHub API and then update button text and link for the users OS
+        fetch("https://api.github.com/repos/kits-ab/LogLady/releases/latest")
+          .then(response => {
+            if (response.status !== 200) {
+              console.error(`GitHub API response not OK: ${response.status}`);
+              return;
+            }
+            response.json().then(data => {
+              // Determine what file extension is the correct one for user
+              let wantedFileExtensionRegex;
+              switch (determineUserOS()) {
+                case "Mac":
+                  downloadButton.innerText = "Download for Mac";
+                  wantedFileExtensionRegex = /\.dmg$/g;
+                  break;
+                case "Linux":
+                  downloadButton.innerText = "Download for Linux";
+                  wantedFileExtensionRegex = /\.AppImage$/g;
+                  break;
+                case "Windows":
+                  downloadButton.innerText = "Download for Windows";
+                  wantedFileExtensionRegex = /\.exe$/g;
+                  break;
+                default:
+                  wantedFileExtensionRegex = /^$/g; // Do-nothing regex
+                  break;
+              }
+
+              // Loop through the assets in the release. Assume there is at least one AppImage, one dmg and one exe
+              for (let index in data.assets) {
+                let asset = data.assets[index];
+                if (wantedFileExtensionRegex.test(asset.name)) {
+                  // Update so the button links directly to the download of a file for the correct OS, if supported
+                  downloadLink = asset.browser_download_url;
+                }
+              }
+            });
+          })
+          .catch(err => {
+            console.error(
+              "An error occured while fetching information about latest release from GitHub API:",
+              err
+            );
+          });
+      };
+    </script>
   </head>
 
   <body>
@@ -176,32 +242,14 @@
         <p>
           Making logs bearable!
         </p>
-        <button class="download-btn" id="download-btn">
-          <script>
-            const macLink =
-              "https://github.com/kits-ab/LogLady/releases/download/v1.0.0/loglady-1.0.0.dmg";
-            const linuxLink =
-              "https://github.com/kits-ab/LogLady/releases/download/v1.0.0/loglady.1.0.0.AppImage";
-            const windowsLink =
-              "https://github.com/kits-ab/LogLady/releases/download/v1.0.0/loglady.Setup.1.0.0.exe";
-            const downloadButton = document.getElementById("download-btn");
-            if (navigator.platform.startsWith("Mac")) {
-              downloadButton.innerHTML = "Download for Mac";
-              downloadButton.onclick = () => (location.href = macLink);
-            } else if (navigator.platform.startsWith("Linux")) {
-              downloadButton.innerHTML = "Download for Linux";
-              downloadButton.onclick = () => (location.href = linuxLink);
-            } else {
-              downloadButton.innerHTML = "Download for Windows";
-              downloadButton.onclick = () => (location.href = windowsLink);
-            }
-          </script>
+        <button class="download-btn">
+          Download on GitHub
         </button>
 
         <p>
           <a
             class="other-platform"
-            href="https://github.com/kits-ab/LogLady/releases"
+            href="https://github.com/kits-ab/LogLady/releases/latest"
             >Other platforms
           </a>
         </p>


### PR DESCRIPTION
I checked earlier pull requests for the website, #293 , and hopefully I have done this right. I _think_ the latest version will be deployed automatically if this PR is merged. Note that this is a merge to branch gh-pages.

I have removed the static download links in the html-document and added a script that makes a request to GitHub API for download links from the latest release instead. It then presents the correct link based on OS, like earlier.
I also added a fallback to link to the latest release on GitHub if either the API can't be used or the OS can't be determined

The GitHub API serves the tag name, e.g. `v.1.1.2` and files are named with that version, e.g. `loglady-1.1.2.dmg`, but I decided to not use that. My script assumes there is one binary file for each OS and that the file extension is either AppImage, dmg or exe. I didn't see a reason to restrict the search of links to the way naming is now.

This should prevent the website from getting outdated when we make new releases! 