### PR TITLE
Feature/notarize macos app #206

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js: "10"
 os: osx
-osx_image: xcode10.2
+osx_image: xcode11.2
 script:
   - npm run lint
   - npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -5209,6 +5209,29 @@
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.1.0.tgz",
       "integrity": "sha512-Z1qA/1oHNowGtSBIcWk0pcLEqYT/j+13xUw/MYOrBUOL4X7VN0i0KCTf5SqyvMPmW5pSPKbo28wkxMxzZ20YnQ=="
     },
+    "electron-notarize": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.2.1.tgz",
+      "integrity": "sha512-oZ6/NhKeXmEKNROiFmRNfytqu3cxqC95sjooG7kBXQVEUSQkZnbiAhxVh5jXngL881G197pbwpeVPJyM7Ikmxw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "electron-publish": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-21.2.0.tgz",
@@ -6662,7 +6685,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6680,11 +6704,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6697,15 +6723,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6808,7 +6837,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6818,6 +6848,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6830,17 +6861,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6857,6 +6891,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -6929,7 +6964,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -6939,6 +6975,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7014,7 +7051,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7044,6 +7082,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7061,6 +7100,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7099,11 +7139,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -9184,6 +9226,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -16947,7 +16990,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -16971,6 +17015,7 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -16983,7 +17028,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -16992,7 +17038,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -17095,7 +17142,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -17105,6 +17153,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -17117,17 +17166,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -17144,6 +17196,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -17216,7 +17269,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -17226,6 +17280,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -17301,7 +17356,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -17331,6 +17387,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -17348,6 +17405,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -17386,11 +17444,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "electron": "^6.0.8",
     "electron-builder": "^21.2.0",
     "electron-devtools-installer": "^2.2.4",
+    "electron-notarize": "^0.2.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "eslint": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   ],
   "build": {
     "appId": "se.kits.loglady",
+    "afterSign": "./public/notarization/notarize.js",
     "files": [
       "src/**/*",
       "build/**/*",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "not op_mini all"
   ],
   "build": {
-    "appId": "com.example.electron-cra",
+    "appId": "se.kits.loglady",
     "files": [
       "src/**/*",
       "build/**/*",
@@ -87,8 +87,14 @@
     ],
     "mac": {
       "category": "Utility",
-      "target": "dmg",
-      "icon": "./public/icons/mac/icon.icns"
+      "icon": "./public/icons/mac/icon.icns",
+      "hardenedRuntime": true,
+      "entitlements": "./public/notarization/entitlements.mac.plist",
+      "entitlementsInherit": "./public/notarization/entitlements.mac.plist",
+      "target": [
+        "dmg",
+        "zip"
+      ]
     },
     "win": {
       "target": "nsis",

--- a/public/notarization/entitlements.mac.plist
+++ b/public/notarization/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+  </dict>
+</plist>

--- a/public/notarization/notarize.js
+++ b/public/notarization/notarize.js
@@ -1,14 +1,42 @@
 const fs = require('fs');
 const { notarize } = require('electron-notarize');
 
+let waitingOutputRunning = false;
+
+/**
+ * log & err: Functions to output a message with a prefix
+ */
 const log = (...args) => {
   console.log('Notarize.js: INFO:', ...args);
 };
-
 const err = (...args) => {
   console.error('Notarize.js: ERROR:', ...args);
 };
 
+/**
+ * Function to start or stop the writing while waiting on notarization
+ */
+const controlWaitingOutput = shouldRun => {
+  waitingOutputRunning = shouldRun;
+
+  // Start writing waiting output, or if finished make a new line
+  if (shouldRun) runWaitingOutput();
+  else process.stdout.write('\n');
+};
+
+/**
+ * Function to write a dot in a single line until told not to
+ */
+async function runWaitingOutput() {
+  // stdout.write instead of console.log so the dots appear on the same line
+  process.stdout.write('.');
+
+  if (waitingOutputRunning) setTimeout(runWaitingOutput, 10000);
+}
+
+/**
+ * Function to check for availability of notarization, and start process if everything is OK
+ */
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== 'darwin') {
@@ -16,6 +44,7 @@ exports.default = async function notarizing(context) {
   }
 
   const appName = context.packager.appInfo.productFilename;
+
   if (fs.existsSync(`${appOutDir}/${appName}.app`)) {
     log(`Attempting to notarize app - ${appOutDir}/${appName}.app.`);
   } else {
@@ -26,7 +55,7 @@ exports.default = async function notarizing(context) {
   if (!process.env.APPLE_ID || !process.env.APPLE_APPPASS) {
     if (process.env.CI && process.env.TRAVIS) {
       log(
-        'Environment variables for notarization not set. If this is a Pull Request build this is expected. Skipping notarization.'
+        'Environment variables for notarization not set. This is expected if this is a PR build to develop. Skipping notarization.'
       );
     } else {
       err('Environment variables for notarization not set.');
@@ -34,14 +63,24 @@ exports.default = async function notarizing(context) {
     return;
   }
 
-  log(
-    'Starting notarization. This step can take some time with no further output if successful!'
-  );
+  log('Starting notarization. This step can take some time!');
 
+  // Start running output, to show something is still happening
+  controlWaitingOutput(true);
   return await notarize({
     appBundleId: `AMTS839RRZ.se.kits.loglady`,
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_ID,
     appleIdPassword: process.env.APPLE_APPPASS
-  });
+  })
+    .then(() => {
+      // Stop running the output
+      controlWaitingOutput(false);
+      log('Done. Notarization seems to have finished successfully!');
+    })
+    .catch(error => {
+      // Stop running the output
+      controlWaitingOutput(false);
+      err('An error occured while notarizing: ', error);
+    });
 };

--- a/public/notarization/notarize.js
+++ b/public/notarization/notarize.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const { notarize } = require('electron-notarize');
+
+const log = (...args) => {
+  console.log('Notarize.js: INFO:', ...args);
+};
+
+const err = (...args) => {
+  console.error('Notarize.js: ERROR:', ...args);
+};
+
+exports.default = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context;
+  if (electronPlatformName !== 'darwin') {
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+  if (fs.existsSync(`${appOutDir}/${appName}.app`)) {
+    log(`Attempting to notarize app - ${appOutDir}/${appName}.app.`);
+  } else {
+    err(`File not found - ${appOutDir}/${appName}.app.`);
+    return;
+  }
+
+  if (!process.env.APPLE_ID || !process.env.APPLE_APPPASS) {
+    if (process.env.CI && process.env.TRAVIS) {
+      log(
+        'Environment variables for notarization not set. If this is a Pull Request build this is expected. Skipping notarization.'
+      );
+    } else {
+      err('Environment variables for notarization not set.');
+    }
+    return;
+  }
+
+  log(
+    'Starting notarization. This step can take some time with no further output if successful!'
+  );
+
+  return await notarize({
+    appBundleId: `AMTS839RRZ.se.kits.loglady`,
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLE_ID,
+    appleIdPassword: process.env.APPLE_APPPASS
+  });
+};


### PR DESCRIPTION
The second step for macOS code signing, notarizing the app!

It works on my machine and Gatekeeper accepts the app afterwards, and I hope it will work on Travis as well.

In this PR I have:
* Added package [electron-notarize](https://github.com/electron/electron-notarize). It's made by the team developing Electron
* Updated the config for electron-builder, as notarization adds a few requirements
* Added a script using electron-notarize, that electron-builder runs after it has signed the app
* Updated the macOS image to the latest version for Travis

I also have:
* Switched the certificate used for signing in Travis - I was using Apple Development when Developer Id should be used.
* Created a Application Id for the application, which is needed for notarization and distribution
* Added environment variables in Travis that are needed for the notarization process

After building locally, I run these commands to check that everything is signed and Gatekeeper trusts the file:
`codesign -dv --verbose=4 dist/mac/loglady.app` which shows the Developer Id certificate is used to sign and it has the correct appid
`spctl --assess --type execute --verbose --ignore-cache --no-cache dist/mac/loglady.app` which shows that Gatekeeper trusts the application because it is notarized and signed using Developer Id

So, everything seems to work great on my end! The notarization step takes a few minutes without any output, so I hope Travis won't timeout because of that.