### PR TITLE
Feature/prototype fabric ui listview #365

### DIFF
--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -1,6 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useState, useRef, useEffect } from 'react';
-import { VariableSizeList } from 'react-window';
 import memoize from 'memoize-one';
 import {
   LogViewerListContainer,
@@ -9,6 +8,7 @@ import {
 import SingleLogLineTranslator from './SingleLogLine';
 
 import _ from 'lodash';
+import { List } from 'office-ui-fabric-react';
 
 const createItemData = memoize(
   (lines, highlightColor, elementWidth, shouldWrap) => {
@@ -83,8 +83,8 @@ const LogViewerList = props => {
         : maxLineLength * characterDimensions.width
     );
     // Clear the list's cache of all item sizes
-    variableSizeListRef.current &&
-      variableSizeListRef.current.resetAfterIndex(0);
+    //variableSizeListRef.current &&
+    //  variableSizeListRef.current.resetAfterIndex(0);
   }, [
     props.wrapLines,
     maxLineLength,
@@ -110,8 +110,10 @@ const LogViewerList = props => {
     setLastLineCount(index);
 
     if (props.scrollToBottom) {
-      variableSizeListOuterRef.current.scrollTop =
-        variableSizeListOuterRef.current.scrollHeight;
+      logViewerListContainerRef.current.scrollTop =
+        logViewerListContainerRef.current.scrollHeight;
+      //variableSizeListOuterRef.current.scrollTop =
+      //  variableSizeListOuterRef.current.scrollHeight;
     }
   }, [props.lines]);
 
@@ -140,12 +142,22 @@ const LogViewerList = props => {
     }
   };
 
+  const _onRenderCell = (item, index) => {
+    return (
+      <SingleLogLineTranslator
+        data={itemData}
+        index={index}
+        style={{ willChange: 'unset' }}
+      ></SingleLogLineTranslator>
+    );
+  };
+
   return (
     <LogViewerListContainer ref={logViewerListContainerRef}>
       <LogLineRuler ref={oneCharacterSizeRef}>
         <span>A</span>
       </LogLineRuler>
-      <VariableSizeList
+      {/* <VariableSizeList
         style={{ willChange: 'unset' }}
         ref={variableSizeListRef}
         outerRef={variableSizeListOuterRef}
@@ -156,7 +168,8 @@ const LogViewerList = props => {
         itemData={itemData}
       >
         {SingleLogLineTranslator}
-      </VariableSizeList>
+      </VariableSizeList> */}
+      <List items={props.lines} onRenderCell={_onRenderCell} />
     </LogViewerListContainer>
   );
 };

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -22,9 +22,6 @@ const createItemData = memoize(
 );
 
 const LogViewerList = props => {
-  const variableSizeListRef = useRef(); // Reference to the React List component. Used for calling the lists functions to reset the cache of sizes
-  const variableSizeListOuterRef = useRef(); // Reference to the actual DOM element. Used for manually scrolling to the bottom
-
   const [logLineElementWidth, setLogLineElementWidth] = useState(1); // Used to save and set the width the LogLine elements should be
   const [maxLineLength, setCurrentMaxLineLength] = useState(1); // Used to save and update how many characters the longest line has
   const [lastLineCount, setLastLineCount] = useState(0); // Used to keep track of how many lines there were last render, for optimizing mainly calculation of new lines
@@ -82,9 +79,6 @@ const LogViewerList = props => {
         ? listDimensions.width
         : maxLineLength * characterDimensions.width
     );
-    // Clear the list's cache of all item sizes
-    //variableSizeListRef.current &&
-    //  variableSizeListRef.current.resetAfterIndex(0);
   }, [
     props.wrapLines,
     maxLineLength,
@@ -112,35 +106,8 @@ const LogViewerList = props => {
     if (props.scrollToBottom) {
       logViewerListContainerRef.current.scrollTop =
         logViewerListContainerRef.current.scrollHeight;
-      //variableSizeListOuterRef.current.scrollTop =
-      //  variableSizeListOuterRef.current.scrollHeight;
     }
   }, [props.lines]);
-
-  /**
-   * Returns the row height needed for an item at position index,
-   * based on if it should wrap lines and how many characters fit in the window
-   * @function
-   * @param {Number} index - the index of the item
-   * @returns The rowheight to use, in pixels.
-   */
-  const getItemSizeAtPosition = index => {
-    if (props.wrapLines) {
-      // Replace all of the stuff hiddenWindow has added to it, as they shouldn't count towards the length of the string
-      let lineWithoutExtrasLength = props.lines[index].replace(
-        /\[\/?HL[LG\d]*\]/g,
-        ''
-      ).length;
-      return (
-        Math.round(
-          (lineWithoutExtrasLength * characterDimensions.width) /
-            logLineElementWidth
-        ) * characterDimensions.height
-      );
-    } else {
-      return characterDimensions.height;
-    }
-  };
 
   const _onRenderCell = (item, index) => {
     return (
@@ -157,18 +124,6 @@ const LogViewerList = props => {
       <LogLineRuler ref={oneCharacterSizeRef}>
         <span>A</span>
       </LogLineRuler>
-      {/* <VariableSizeList
-        style={{ willChange: 'unset' }}
-        ref={variableSizeListRef}
-        outerRef={variableSizeListOuterRef}
-        width={listDimensions.width}
-        height={listDimensions.height}
-        itemCount={props.lines.length}
-        itemSize={getItemSizeAtPosition}
-        itemData={itemData}
-      >
-        {SingleLogLineTranslator}
-      </VariableSizeList> */}
       <List items={props.lines} onRenderCell={_onRenderCell} />
     </LogViewerListContainer>
   );

--- a/src/js/view/components/SingleLogLine.js
+++ b/src/js/view/components/SingleLogLine.js
@@ -15,6 +15,7 @@ const MemoedSingleLogLine = React.memo(props => {
         width: props.elementWidth + 'px'
       }}
       wrap={props.shouldWrap ? 'true' : undefined}
+      index={props.index}
     >
       {/^\[HLL\].*\[\/HLL\]$/.test(props.line) ? (
         <TextHighlightRegex text={props.line} color={props.highlightColor} />
@@ -39,6 +40,7 @@ const SingleLogLineTranslator = React.memo(({ data, index, style }) => {
       highlightColor={data.highlightColor}
       elementWidth={data.elementWidth}
       shouldWrap={data.shouldWrap}
+      index={index}
     ></MemoedSingleLogLine>
   );
 });

--- a/src/js/view/styledComponents/LogViewerListStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerListStyledComponents.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const LogViewerListContainer = styled.div`
   width: 100%;
   height: 100%;
+  overflow: auto;
 `;
 
 export const LogLine = styled.div`

--- a/src/js/view/styledComponents/LogViewerListStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerListStyledComponents.js
@@ -8,12 +8,11 @@ export const LogViewerListContainer = styled.div`
 
 export const LogLine = styled.div`
   min-width: 100%;
-  background-color: #444;
+  background-color: ${props => {
+    return props.index % 2 === 0 ? '#444' : '#303030';
+  }};
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
-  :nth-child(odd) {
-    background-color: #303030;
-  }
   white-space: ${props => {
     return props.wrap ? 'normal' : 'nowrap';
   }};


### PR DESCRIPTION
I have changed the list-component from react-window's VariableSizeList to Fabric UI's List. I was able to remove some code, mostly related to keeping track of the size of the VariableSizeList, which seems to be handled automatically by Fabric.

I also had to move the scrolling element to the list container, this was done simply by adding `overflow: auto` to the styled component.

Lastly, I had to change how the LogLine determines it's background color. Previously this was done using the nth-child CSS property, but Fabric UI wraps each list item in a list item container which made each LogLine be the first child, thus they all had the same background color. Now, I send the index of the item in datalist to the component, and the background color is based on that instead.