### PR TITLE
#352 Simplify release process for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
-node_js: "10"
+node_js: '10'
 os: osx
 osx_image: xcode11.2
 script:
+  - export APP_VERSION=$(npm run echo-version --silent)
   - npm run lint
   - npm test
   - npm run electron-pack
@@ -10,14 +11,19 @@ branches:
   only:
     - master
     - develop
+before_deploy:
+  - git config --local user.name 'kitsmechanicalturk'
+  - git config --local user.email 'info@kits.se'
+  - export VERSION_TAG=v${APP_VERSION}
+  - git tag $VERSION_TAG
 deploy:
   provider: releases
   api_key:
     secure: hHEJcTGLLjtbk1foVHkn/u7JBl1N9x/TwkMq5fX8JVWCRdcXL06NZnwbt8vb/Ah7CLgvXvGrn77aU0qWlbtj8d+MBo7oTW/dgGzT7PyXKhq4uj+E6KYFcmjCJv3tSHxy4H3U304IRuXYQGhzKZceuvVUSKUReKUz64ICDwJvPnU57tYo1jLKv8T5ZQTgQZvd8roAhxhLKND/gatayr+4Jdyzr/LAwx3jeweWNFFOaBkgiwSov6cuf4GVQ9zk5SwqnKdNiTQp5h1mRbYLqem6qIyEgU7X3g8rVff4LumqqyL9jpqjAf0ppujgFL8dZ6ktAkIWo7/8DpA7Jfkf0MNg6e0FVos6r7/EWdgu3/OPRCTn6bSHznv15jpxclSzIV5uXjrcGXUgljm8oAUfyUQTYSn9xKMv+cgvO0OtmjfYE7hgNwt3odtcUp0jeKi4NJvuzDVaC+56QCFbx+bgkTUfS1ypmV6u3f5eNyDtd5mIPaE11pBXQP2CoKXvxFqLNodjxSe5vTB9cqeaHMmYgSYvhfD6jfvV77LFIyB+RjQfnbq9JZXMiZlhjFn6cNkUfK58oHxCpGTeMQ4qBekCbN7syWMJqNSUTjHbc+sZncexwPnMAg8gCmLCeY26bitXDAauiizm13Gof337AG52w88tzAOkqFpa1gOR+T8wyOnbqEs=
   file:
-    - 'dist/loglady-1.1.4.AppImage'
-    - 'dist/loglady-1.1.4.dmg'
-    - 'dist/loglady Setup 1.1.4.exe'
+    - 'dist/loglady-${APP_VERSION}.AppImage'
+    - 'dist/loglady-${APP_VERSION}.dmg'
+    - 'dist/loglady Setup ${APP_VERSION}.exe'
   skip_cleanup: true
   on:
     branch: master

--- a/README.md
+++ b/README.md
@@ -63,7 +63,16 @@ Commit messages should start with task ID
 
 Example: `#5 update README. Explained naming.`
 
-Push when done. Make pull request where you add task ID to beginning of comment.
+Push when done. Make pull request to develop (Merge the created branch into develop) where you add task ID to beginning of comment.
+
+## Creating a new release
+
+Travis is currently used for building and deploying to GitHub Releases. When the project is ready for a new release you need to:
+
+* Update the version field in `package.json`, using [semantic versioning](https://semver.org/)
+* Make a pull request to master with all the changes from develop (Merge develop into master)
+* Wait for the Travis build to finish
+* Update the release title and description found on [GitHub Releases](https://github.com/kits-ab/LogLady/releases/latest)
 
 ## Useful links
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "eject": "react-scripts eject",
     "dev": "concurrently \"BROWSER=none npm start\" \"wait-on http://localhost:3000 && electron --inspect .\"",
     "electron-pack": "electron-builder -lmw",
-    "preelectron-pack": "npm run build"
+    "preelectron-pack": "npm run build",
+    "echo-version": "echo $npm_package_version"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Another small PR! But this one should improve the process of creating a new release in the future - all that is needed now is to change the version in package.json!

In this PR I have:
* Added a new command to npm that returns the version number from package.json
* Updated Travis conf to export the result from the command above as an environment variable
* Updated Travis conf to use the environment variable to create a new tag and find the correct files to release
* Updated the README on how to make a new release

I have tried it out on a private repo and everything worked there, so it shouldn't be a problem for this repo.