### PR TITLE
 #386 Update notarize.js to use env variable as a string

### DIFF
--- a/public/notarization/notarize.js
+++ b/public/notarization/notarize.js
@@ -1,3 +1,5 @@
+/* eslint-disable eqeqeq */
+
 const fs = require('fs');
 const { notarize } = require('electron-notarize');
 
@@ -48,7 +50,7 @@ exports.default = async function notarizing(context) {
 
   const appName = context.packager.appInfo.productFilename;
 
-  if (process.env.TRAVIS_PULL_REQUEST) {
+  if (process.env.TRAVIS_PULL_REQUEST != 'false') {
     log('This is a Pull Request build. Skipping notarization.');
     return;
   }

--- a/public/notarization/notarize.js
+++ b/public/notarization/notarize.js
@@ -55,6 +55,11 @@ exports.default = async function notarizing(context) {
     return;
   }
 
+  if (process.env.TRAVIS_BRANCH != 'master') {
+    log("This isn't a build on master branch. Skipping notarization.");
+    return;
+  }
+
   if (!process.env.APPLE_ID || !process.env.APPLE_APPPASS) {
     err('Environment variables for notarization not set. Aborting.');
     return;


### PR DESCRIPTION
#386 A quick hotfix for this bug.

When I wrote the script earlier I read the docs and thought that TRAVIS_PULL_REQUEST would be either the PR number or `false` - and as such I could use it as falsy.

Turns out that didn't work, and the docs actually mention the variable to `"false"` if build is not a PR. I have fixed this in this PR, but this also means that the latest release has not been notarized.