### PR TITLE
#387 Update Travis conf so deploy only runs on master builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ stages:
     if: branch = develop OR type = pull_request
   - name: deploy
     # Only package app and deploy when build is triggered on master
-    if: branch = master
+    if: branch = master AND type != pull_request
 if: branch IN (master, develop) OR type = pull_request


### PR DESCRIPTION
#387 Another simple hotfix for a mistake I did 😬

This time, Travis was configured so the deploy stage was run on pull requests to master. This wasn't intended, only builds triggered by pushes to master should try to deploy. For pull requests and builds on develop only the package stage should run.

I fixed it by adding another conditional for if the build was triggered by a pull request, and if so deploy will be silently skipped.
The conditionals are designed to be opposite - if the package stage should run the deploy stage won't run and vice versa.