### PR TITLE
#394 Add hotkeys for switching tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10925,6 +10925,11 @@
       "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
       "dev": true
     },
+    "mousetrap": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.3.tgz",
+      "integrity": "sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash": "^4.17.15",
     "md5": "^2.2.1",
     "memoize-one": "^5.1.1",
+    "mousetrap": "^1.6.3",
     "node-notifier": "^5.4.3",
     "nthline": "^1.0.1",
     "office-ui-fabric-react": "^7.68.0",
@@ -117,7 +118,7 @@
   },
   "jest": {
     "transformIgnorePatterns": [
-        "/node_modules/(?!office-ui-fabric-react/.*)"
-      ]
+      "/node_modules/(?!office-ui-fabric-react/.*)"
+    ]
   }
 }


### PR DESCRIPTION
Closes #394

I have added keybinds for switching tabs, by using ctrl+tab to move to the right and ctrl+shift+tab to move to the left.

When I converted the note to an issue it says opened by me - which isn't correct, this was a great idea by Doverstav!

In this PR I have:
* Added package [mousetrap](https://www.npmjs.com/package/mousetrap), it's a simple library for keybinds with no dependencies. It made it easier to add keybinds with multiple keys and bind/unbind them within React
* Updated `TabPanelContainer.js` to register the keybinds, unbind when needed, and use a handler to know what tab to switch to. It uses the existing function `tabOnClick` to actually switch to the tab!