### PR TITLE
#381 Set root container box-sizing to 'border-box'

### DIFF
--- a/src/js/view/styledComponents/AppStyledComponents.js
+++ b/src/js/view/styledComponents/AppStyledComponents.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export const RootContainer = styled.div`
+  box-sizing: border-box;
   display: flex;
   height: 100vh;
   max-height: 100vh;


### PR DESCRIPTION
The root container component was displaying a vertical scrollbar due to the newly added 1 pixel top border.   

This border was deemed to be needed to create some separation between the menu and the top panel, so to remove this scrollbar but retain the top border, the box sizing of the root container was changed to `border-box`.   

This changes the size calculation of the box to include border and padding when calculation box size, which results in the vertical scrollbar disappearing.