### PR TITLE
#412 Fix notarize.js infinite loop

### DIFF
--- a/public/notarization/notarize.js
+++ b/public/notarization/notarize.js
@@ -20,8 +20,8 @@ const err = (...args) => {
  */
 const controlWaitingOutput = shouldRun => {
   // Start writing waiting output, or if finished make a new line
-  if (shouldRun && !waitingOutputRunning) {
-    waitingOutputRunning = shouldRun;
+  waitingOutputRunning = shouldRun;
+  if (waitingOutputRunning) {
     runWaitingOutput();
   } else {
     process.stdout.write('\n');


### PR DESCRIPTION
#412 

See issue for more details. Short summary: The notarize script gets caught in an endless loop due to a boolean flag not being set correctly.  

I made a quick truthtable to show that the current conditional does not work:  

| shouldRun | waitingOutputRunning | shouldRun && !waitingOutputRunning         |
| --------- | -------------------- | ------------------------------------------ |
| T         | F                    | T                                          |
| F         | F                    | F                                          |
| T         | T                    | F                                          |
| F         | T                    | F (Will not stop running though it should) |

The suggested fix of turning it into an OR-expression won't work either, as seen in this truthtable: 
 
| shouldRun | waitingOutputRunning | shouldRun \|\| !waitingOutputRunning        |
| --------- | -------------------- | ------------------------------------------- |
| T         | F                    | T                                           |
| F         | F                    | T                                           |
| T         | T                    | T                                           |
| F         | T                    | F  (Will not stop running though it should) |

What I did instead to solve the issue was to set `waitingOutputRunning = shouldRun` before the conditional instead of inside it, and simplified to condition to be simply `waitingOutputRunning`.  

This should ensure that `waitingOutputRunning` is correctly set when `controlWaitingOutput()` is called, and `runWaitingOutput()` (see line 34) should terminate its logging-loop correctly.