### PR TITLE
#399 Lines in logviewer now highlights when colors are chosen from the color picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "loglady",
-  "version": "v1.1.5",
+  "version": "v1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -61,7 +61,7 @@ const LogViewer = props => {
         logs: props.logs[props.source.path]
       });
     }
-  }, [props.filterInput, props.highlightInput]);
+  }, [props.filterInput, props.highlightInput, props.highlightColor]);
 
   useEffect(() => {
     // Effect for when new lines are added

--- a/src/js/view/styledComponents/TextHighlightRegexStyledComponents.js
+++ b/src/js/view/styledComponents/TextHighlightRegexStyledComponents.js
@@ -37,5 +37,5 @@ export const HighlightMatch = styled.span`
   background: yellow;
   opacity: 0.5;
   color: black;
-  fontweight: bold;
+  font-weight: bold;
 `;


### PR DESCRIPTION

Solved by adding the highlightColor prop to the array in useEffect in LogViewer.js

```
  useEffect(() => {
    /* Effect for when a new filter or highlight is applied,
    send the lines to be filtered and highlighted again */
    if (props.logs[props.source.path]) {
      // Reset the previous lines count, as all lines should be wiped.
      previousLinesLength.current = 0;
      sendMessageToHiddenWindow({
        logs: props.logs[props.source.path]
      });
    }
  }, [props.filterInput, props.highlightInput, props.highlightColor]);
```