### PR TITLE
#434 Get text from position from adapter

### DIFF
--- a/src/js/adapters/fileReader.js
+++ b/src/js/adapters/fileReader.js
@@ -305,11 +305,21 @@ const parseSelectedData = (data, start, numberOfBytes) => {
   const lineSizeTop = Buffer.byteLength(lines[0], 'utf8');
   const lineSizeBottom = Buffer.byteLength(lines[lines.length - 1], 'utf8');
 
-  let linesStartAt = start + lineSizeTop;
-  let linesEndAt = start + numberOfBytes - lineSizeBottom;
+  let linesStartAt = start;
+  let linesEndAt = start + numberOfBytes;
 
-  lines.shift();
-  lines.pop();
+  // We aren't reading from the beginning of the file
+  if (start !== 0) {
+    linesStartAt = start + lineSizeTop;
+    lines.shift();
+  }
+
+  // If lines does not end in a newline, last line is incomplete
+  // and should be removed
+  if (!isLF(data.charAt(data.length - 1))) {
+    linesEndAt = start + numberOfBytes - lineSizeBottom;
+    lines.pop();
+  }
 
   return {
     lines,

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -162,7 +162,7 @@ const readLinesStartingAtByte = async data => {
   let bytesPerScreen = lines * APPROXIMATE_BYTES_PER_LINE;
   // Fetch lines from one screen back to current position
   let startBytesMinusOneScreen =
-    startByte - bytesPerScreen > 0 ? startByte - bytesPerScreen : 1;
+    startByte - bytesPerScreen > 0 ? startByte - bytesPerScreen : 0;
   // Fetch three screens total
   let bytesToFetch = bytesPerScreen * SCREENS_TO_FETCH;
   let byteToReadFrom = startBytesMinusOneScreen;
@@ -188,6 +188,8 @@ const readLinesStartingAtByte = async data => {
     dataToReturn.lines = dataToReturn.lines.concat(data.lines);
 
     // Calculate next byte to read from
+    // Remove one byte to get one character from previous line,
+    // which will be discarded by the adapter
     byteToReadFrom = dataToReturn.linesEndAt - 1;
   }
 

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -147,6 +147,37 @@ const handleShowOpenDialog = async (state, sender) => {
     });
 };
 
+const readLinesStartingAtByte = (path, startByte, lines) => {
+  const APPROXIMATE_BYTES_PER_LINE = 150;
+  const SCREENS_TO_FETCH = 3;
+  let dataToReturn = {
+    lines: [],
+    linesEndAt: 0
+  };
+
+  // Convert lines to amount of bytes using approximation
+  let bytesPerScreen = lines * APPROXIMATE_BYTES_PER_LINE;
+  // Fetch lines from one screen back to current position
+  let startBytesMinusOneScreen = startByte - bytesPerScreen;
+  // Fetch three screens total
+  let bytesToFetch = bytesPerScreen * SCREENS_TO_FETCH;
+
+  // Fetch data from adapter
+  while (dataToReturn.lines.length < lines) {
+    let byteToReadFrom = startBytesMinusOneScreen + dataToReturn.linesEndAt - 1;
+    // Om inte, hämta fler rader
+    let data = fileReader.readDataFromByte(path, byteToReadFrom, bytesToFetch);
+
+    if (!dataToReturn.linesStartAt) {
+      dataToReturn.linesStartAt = data.linesStartAt;
+    }
+    dataToReturn.linesEndAt = data.linesEndAt;
+    dataToReturn.lines = dataToReturn.lines.concat(data.lines);
+  }
+
+  return dataToReturn;
+};
+
 const sendError = (sender, message, error) => {
   const errorSender = error => {
     const action = {

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -170,7 +170,7 @@ const readLinesStartingAtByte = async data => {
   // If too few lines are returned and we have not
   // reached the end of file, keep reading lines
   while (
-    dataToReturn.lines.length < lines &&
+    dataToReturn.lines.length < lines * SCREENS_TO_FETCH &&
     dataToReturn.linesEndAt < fileSize
   ) {
     // Fetch data from adapter

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -147,7 +147,8 @@ const handleShowOpenDialog = async (state, sender) => {
     });
 };
 
-const readLinesStartingAtByte = (path, startByte, lines) => {
+const readLinesStartingAtByte = data => {
+  let { path, startByte, lines } = data;
   const APPROXIMATE_BYTES_PER_LINE = 150;
   const SCREENS_TO_FETCH = 3;
   let dataToReturn = {
@@ -158,24 +159,25 @@ const readLinesStartingAtByte = (path, startByte, lines) => {
   // Convert lines to amount of bytes using approximation
   let bytesPerScreen = lines * APPROXIMATE_BYTES_PER_LINE;
   // Fetch lines from one screen back to current position
-  let startBytesMinusOneScreen = startByte - bytesPerScreen;
+  let startBytesMinusOneScreen =
+    startByte - bytesPerScreen > 0 ? startByte - bytesPerScreen : 1;
   // Fetch three screens total
   let bytesToFetch = bytesPerScreen * SCREENS_TO_FETCH;
 
   // Fetch data from adapter
-  while (dataToReturn.lines.length < lines) {
-    let byteToReadFrom = startBytesMinusOneScreen + dataToReturn.linesEndAt - 1;
-    // Om inte, hämta fler rader
-    let data = fileReader.readDataFromByte(path, byteToReadFrom, bytesToFetch);
+  let byteToReadFrom = startBytesMinusOneScreen + dataToReturn.linesEndAt - 1;
 
+  fileReader.readDataFromByte(path, byteToReadFrom, bytesToFetch).then(data => {
     if (!dataToReturn.linesStartAt) {
       dataToReturn.linesStartAt = data.linesStartAt;
     }
     dataToReturn.linesEndAt = data.linesEndAt;
     dataToReturn.lines = dataToReturn.lines.concat(data.lines);
-  }
 
-  return dataToReturn;
+    console.log(dataToReturn);
+
+    return dataToReturn;
+  });
 };
 
 const sendError = (sender, message, error) => {
@@ -220,6 +222,9 @@ const createEventHandler = state => {
         break;
       case 'STATE_LOAD':
         loadStateFromDisk(state, sender);
+        break;
+      case 'TEST_BYTE_READ':
+        readLinesStartingAtByte(_argObj.data);
         break;
       default:
     }


### PR DESCRIPTION
#434

Engine can now request text with position from adapter. It tries to do this in a smart way by estimating the bytes in a line and then fetch one screen behind and one screen ahead in order to build a buffer. If, for some reason, the lines are very long and not enough lines were returned in a single request, it will make more requests until it gets enough lines. The exception to this is if it reaches the end of the file, where it instead will stop requesting and return the lines it has gotten up until this point.

This pull request also fixes an issue in adapter with reading the last and first line of a file.