### PR TITLE
Feature/ask backend for text based on byte position

### DIFF
--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -147,7 +147,7 @@ const handleShowOpenDialog = async (state, sender) => {
     });
 };
 
-const readLinesStartingAtByte = async data => {
+const readLinesStartingAtByte = async (sender, data) => {
   const APPROXIMATE_BYTES_PER_LINE = 150;
   const SCREENS_TO_FETCH = 3;
   const { path, startByte, lines } = data;
@@ -192,8 +192,11 @@ const readLinesStartingAtByte = async data => {
     // which will be discarded by the adapter
     byteToReadFrom = dataToReturn.linesEndAt - 1;
   }
-
-  return dataToReturn;
+  const action = {
+    type: 'LINES_FROM_BYTE',
+    data: { dataToReturn, path }
+  };
+  sender.send(ipcChannel, action);
 };
 
 const sendError = (sender, message, error) => {
@@ -239,8 +242,8 @@ const createEventHandler = state => {
       case 'STATE_LOAD':
         loadStateFromDisk(state, sender);
         break;
-      case 'TEST_BYTE_READ':
-        readLinesStartingAtByte(_argObj.data);
+      case 'READ_LINES_AT_BYTE':
+        readLinesStartingAtByte(sender, _argObj.data);
         break;
       default:
     }

--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -191,3 +191,21 @@ export const showSnackBar = (dispatch, message, level) => {
     }
   });
 };
+
+export const addLinesFetchedFromBytePosition = (
+  dispatch,
+  lines,
+  linesStartAt,
+  linesEndAt,
+  sourcePath
+) => {
+  dispatch({
+    type: 'LOGVIEWER_ADD_LINES_FROM_BYTE_POSITION',
+    data: {
+      lines,
+      linesStartAt,
+      linesEndAt,
+      sourcePath
+    }
+  });
+};

--- a/src/js/view/components/helpers/logHelper.js
+++ b/src/js/view/components/helpers/logHelper.js
@@ -1,4 +1,5 @@
 import { calculateWrappedHeight } from './measureHelper';
+import { sendRequestToBackend } from 'js/view/ipcPublisher';
 
 export const createHeightReducer = (charSize, elWidth) => {
   return (map, next) => {
@@ -19,4 +20,16 @@ export const createRegexReducer = regex => {
 
 export const scrollToBottom = (el, list) => {
   el.scrollAround(list.length - 1);
+};
+
+export const fetchTextBasedOnByteFromScrollPosition = (
+  path,
+  startByte,
+  lines
+) => {
+  const argObj = {
+    function: 'READ_LINES_AT_BYTE',
+    data: { path, startByte, lines }
+  };
+  sendRequestToBackend(argObj);
 };

--- a/src/js/view/ipcListener.js
+++ b/src/js/view/ipcListener.js
@@ -4,7 +4,8 @@ import {
   showSnackBar,
   addNewLines,
   increaseSize,
-  setLastSeenLogSizeToSize
+  setLastSeenLogSizeToSize,
+  addLinesFetchedFromBytePosition
 } from 'js/view/actions/dispatchActions';
 import { sendRequestToBackend } from 'js/view/ipcPublisher';
 import { prettifyErrorMessage } from 'js/view/components/helpers/errorHelper';
@@ -71,6 +72,17 @@ const handleNewLines = (dispatch, { sourcePath, lines, size }) => {
   increaseSize(dispatch, sourcePath, size);
 };
 
+const handleLinesFromByte = (dispatch, { dataToReturn, path }) => {
+  console.log(dataToReturn, path);
+  addLinesFetchedFromBytePosition(
+    dispatch,
+    dataToReturn.lines,
+    dataToReturn.linesStartAt,
+    dataToReturn.linesEndAt,
+    path
+  );
+};
+
 const handleError = (dispatch, { message, error }) => {
   const errorMessage = prettifyErrorMessage(message, error);
   showSnackBar(dispatch, errorMessage, 'error');
@@ -98,6 +110,9 @@ export const ipcListener = (store, publisher) => {
         break;
       case 'LINES_NEW':
         handleNewLines(dispatch, action.data);
+        break;
+      case 'LINES_FROM_BYTE':
+        handleLinesFromByte(dispatch, action.data);
         break;
       default:
         console.log('Warning: Unrecognized message, ', action);

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -37,6 +37,18 @@ export const logViewerReducer = (state = initialState, action) => {
           [sourcePath]: log ? [...log, ...lines] : [...lines]
         }
       };
+    case 'LOGVIEWER_ADD_LINES_FROM_BYTE_POSITION': {
+      const { lines, sourcePath } = action.data;
+      const log = state.logs[sourcePath];
+
+      return {
+        ...state,
+        logs: {
+          ...state.logs,
+          [sourcePath]: log ? [...lines, ...log] : [...lines]
+        }
+      };
+    }
 
     default:
       return state;


### PR DESCRIPTION
The frontend is now able to send a request to backend for fetching a text and start/end bytes info based on a byte position in the file. Backend sends it back and the listener adds it to the log viewer's state.  