### PR TITLE
#447 Fix issue with number under tab

### DIFF
--- a/src/js/view/reducers/menuReducer.js
+++ b/src/js/view/reducers/menuReducer.js
@@ -1,5 +1,5 @@
 const initialState = {
-  nextIndex: 0,
+  nextIndex: 1,
   openSources: {},
   currentSourceHandle: undefined
 };


### PR DESCRIPTION
The issue regarding the 0 appearing under tab when reduxState.json is empty seems to be solved when letting nextIndex in initialState start at 1 instead of 0. The issue still does not appear when reduxState.json is containing a saved state.