### PR TITLE
#453 Fix highlightning issue

### DIFF
--- a/src/js/hiddenWindow/mainScriptOffloader.js
+++ b/src/js/hiddenWindow/mainScriptOffloader.js
@@ -48,7 +48,7 @@ class LogsFiltererAndHighlighter {
           let highlightCount = 0;
           line =
             '[HLL]' +
-            line.replace(this.highlightRegex, match => {
+            line.trim().replace(this.highlightRegex, match => {
               return (
                 `[HLG${++highlightCount}]` + match + `[/HLG${highlightCount}]`
               );


### PR DESCRIPTION
When replacing a line with a highlighted variant there seem to be some whitespace in the end and/or beginning of the last row, causing it to fail highlighting that row. By trimming line (at row 51) before using replace the last row appear to be highlighted correctly.