### PR TITLE
 #464 #461 Move slider to its own file and fix related bugs

### DIFF
--- a/src/js/adapters/fileReader.js
+++ b/src/js/adapters/fileReader.js
@@ -254,7 +254,7 @@ const saveStateToDisk = _reduxStateValue => {
     if (err) {
       throw err;
     }
-    console.log('LogLady: state has been succefully saved to disk.');
+    console.log('LogLady: state has been successfully saved to disk.');
     return 'success';
   });
 };
@@ -268,7 +268,7 @@ const saveRecentFilesToDisk = _recentFiles => {
     if (err) {
       throw err;
     }
-    console.log('LogLady: recent files have been succefully saved to disk.');
+    console.log('LogLady: recent files have been successfully saved to disk.');
     return 'success';
   });
 };

--- a/src/js/view/components/CustomScrollBar.js
+++ b/src/js/view/components/CustomScrollBar.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Slider } from 'office-ui-fabric-react';
+import { ScrollBarContainer } from '../styledComponents/LogViewerStyledComponents';
+
+/*
+Custom scroll bar created from fabric-ui slider component.
+With this we are able to connect the position of the slider thumb to specific bytes in the file. 
+*/
+
+// Object with all the values that can be overridden in the slider component
+const overrideStyles = {
+  activeSection: {},
+  container: {},
+  inactiveSection: {},
+  line: {},
+  lineContainer: {},
+  root: {},
+  slideBox: {},
+  thumb: {},
+  titleLabel: {},
+  valueLabel: {},
+  zeroTick: {}
+};
+
+const CustomScrollBar = props => {
+  return (
+    <ScrollBarContainer>
+      <Slider
+        min={0}
+        max={props.logSize}
+        onChange={value => {
+          props.handleOnChange(value);
+        }}
+        showValue={false}
+        step={props.step}
+        styles={overrideStyles}
+        value={props.scrollPosition}
+        vertical
+      />
+    </ScrollBarContainer>
+  );
+};
+
+export default CustomScrollBar;

--- a/src/js/view/components/CustomScrollBar.js
+++ b/src/js/view/components/CustomScrollBar.js
@@ -1,43 +1,60 @@
 import React from 'react';
 import { Slider } from 'office-ui-fabric-react';
-import { ScrollBarContainer } from '../styledComponents/LogViewerStyledComponents';
 
 /*
 Custom scroll bar created from fabric-ui slider component.
 With this we are able to connect the position of the slider thumb to specific bytes in the file. 
 */
 
-// Object with all the values that can be overridden in the slider component
-const overrideStyles = {
-  activeSection: {},
-  container: {},
-  inactiveSection: {},
-  line: {},
-  lineContainer: {},
-  root: {},
-  slideBox: {},
-  thumb: {},
-  titleLabel: {},
-  valueLabel: {},
-  zeroTick: {}
-};
-
 const CustomScrollBar = props => {
+  // All elements of the slider that can have their styles overridden.
+  const overrideStyles = {
+    activeSection: { backgroundColor: 'transparent' },
+    container: {},
+    inactiveSection: { backgroundColor: 'transparent' },
+    line: {},
+    lineContainer: {},
+    root: {
+      marginRight: '0px'
+    },
+    slideBox: {
+      paddingTop: '0px',
+      width: '20px',
+      selectors: {
+        ':hover': {}
+      }
+    },
+    thumb: {
+      backgroundColor: 'rgb(200, 198, 196)',
+      border: 'none',
+      borderRadius: 'none',
+      height: '20px',
+      transform: 'translateY(0px)',
+      selectors: {
+        ':hover': {
+          backgroundColor: 'darkGrey',
+          border: 'none'
+        }
+      }
+    },
+    titleLabel: {},
+    valueLabel: {},
+    zeroTick: {}
+  };
+
   return (
-    <ScrollBarContainer>
-      <Slider
-        min={0}
-        max={props.logSize}
-        onChange={value => {
-          props.handleOnChange(value);
-        }}
-        showValue={false}
-        step={props.step}
-        styles={overrideStyles}
-        value={props.scrollPosition}
-        vertical
-      />
-    </ScrollBarContainer>
+    <Slider
+      min={0}
+      max={props.logSize}
+      onChange={value => {
+        props.handleOnChange(value);
+      }}
+      showValue={false}
+      step={props.step}
+      styles={overrideStyles}
+      value={props.scrollPosition}
+      vertical
+    />
   );
 };
 

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -46,7 +46,6 @@ const LogViewer = props => {
   const [currentLogViewerContainerHeight, setCurrentContainerHeight] = useState(
     0
   );
-
   let previousLinesLength = useRef(0); // Used to keep track of how many lines there were last time useEffect was called, for optimizing and only sending the new lines
   const logViewerContainerRef = useRef();
 
@@ -96,7 +95,7 @@ const LogViewer = props => {
 
   useEffect(() => {
     const logViewerContainerResizeHandler = _.debounce(() => {
-      setCurrentContainerHeight(logViewerContainerRef.current.offsetHeight);
+      setCurrentContainerHeight(logViewerContainerRef.current.clientHeight);
     }, 50);
     logViewerContainerResizeHandler();
     window.addEventListener('resize', logViewerContainerResizeHandler);
@@ -222,7 +221,7 @@ const LogViewer = props => {
     scrollPosition,
     currentTimeout,
     currentLogViewerContainerHeight,
-    props.nroflines
+    props.nrOfLinesInViewer
   ]);
 
   const handleCustomScrollBarOnChange = value => {

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState, useRef } from 'react';
 import {
-  LogViewerParent,
+  LogViewerRootContainer,
   LogViewerContainer
 } from '../styledComponents/LogViewerStyledComponents';
 import LogViewerList from './LogViewerList';
@@ -239,7 +239,7 @@ const LogViewer = props => {
   };
 
   return (
-    <LogViewerParent>
+    <LogViewerRootContainer>
       <LogViewerContainer ref={logViewerContainerRef}>
         <LogViewerList
           key={props.source.index}
@@ -258,7 +258,7 @@ const LogViewer = props => {
         scrollPosition={scrollPosition}
         step={1}
       />
-    </LogViewerParent>
+    </LogViewerRootContainer>
   );
 };
 

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -35,7 +35,7 @@ const LogViewerList = props => {
   const oneCharacterSizeRef = useRef();
   const [characterDimensions, setCharacterDimensions] = useState({
     width: 10,
-    height: 17
+    height: 19
   });
 
   const [numberOfLinesToFillLogView, setNumberOfLinesToFillLogView] = useState(
@@ -107,11 +107,11 @@ const LogViewerList = props => {
   }, [props.lines]);
 
   useEffect(() => {
-    // Calculating the correct amount of lines needed to fill the page in the logviewer
+    // Calculating the amount of lines needed to fill the page in the logviewer
     setNumberOfLinesToFillLogView(
-      Math.round(props.containerHeight / characterDimensions.height - 2)
+      Math.round(props.containerHeight / characterDimensions.height)
     );
-  }, [props.containerHeight]);
+  }, [props.containerHeight, characterDimensions]);
 
   useEffect(() => {
     updateNumberOfLinesToRenderInLogView(

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -109,7 +109,7 @@ const LogViewerList = props => {
   useEffect(() => {
     // Calculating the correct amount of lines needed to fill the page in the logviewer
     setNumberOfLinesToFillLogView(
-      Math.round(props.containerHeight / characterDimensions.height)
+      Math.round(props.containerHeight / characterDimensions.height - 2)
     );
   }, [props.containerHeight]);
 

--- a/src/js/view/styledComponents/LogViewerListStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerListStyledComponents.js
@@ -3,8 +3,7 @@ import styled from 'styled-components';
 export const LogViewerListContainer = styled.div`
   width: 100%;
   height: 100%;
-  /* overflow: auto; */
-  margin-bottom: 20%;
+  /* padding-bottom: 20%; */
 `;
 
 export const LogLine = styled.div`

--- a/src/js/view/styledComponents/LogViewerListStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerListStyledComponents.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 export const LogViewerListContainer = styled.div`
   width: 100%;
   height: 100%;
-  /* padding-bottom: 20%; */
 `;
 
 export const LogLine = styled.div`

--- a/src/js/view/styledComponents/LogViewerStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerStyledComponents.js
@@ -3,8 +3,7 @@ import styled from 'styled-components';
 export const LogViewerRootContainer = styled.div`
   display: flex;
   flex: 1;
-  /* height: calc(100% - 32px); */
-  height: 80%;
+  height: calc(100% - 32px);
 `;
 
 export const LogViewerContainer = styled.div`

--- a/src/js/view/styledComponents/LogViewerStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerStyledComponents.js
@@ -1,14 +1,23 @@
 import styled from 'styled-components';
 
+export const LogViewerRootContainer = styled.div`
+  display: flex;
+  flex: 1;
+  /* height: calc(100% - 32px); */
+  height: 80%;
+`;
+
 export const LogViewerContainer = styled.div`
   display: flex;
   flex: 1;
   border: 1px solid white;
   color: #ccc;
   background: #444;
-  height: calc(100% - 32px);
+  height: 100%;
   overflow-anchor: none;
   min-width: 0;
+  overflow-y: hidden;
+  overflow-x: auto;
 `;
 
 export const CloseFileButton = styled.button`


### PR DESCRIPTION
- Moved the slider to its own file, named it CustomScrollBar and added some quick styling before positioning it by the logviewer. 

- I also renamed the slider code in the LogViewer to have names related to scroll instead of slider.   

-  Created a log viewer root container and placed the custom scroller next to the log viewer. It now stays where it should even when the lines are long. 

-  Added overflow-x: auto to the logviewer container to make the length of the file readable.

-  Finally some issues occurred when calculating the amount of lines to fill the viewer. It was based on offsetHeight. It did not take the horisontal scrollbar into account. I changed offsetHeight to clientHeight and it seems to be more accurate.