### PR TITLE
#472 Round bytes to read to nearest integer, save timeout correctly

### DIFF
--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -10,7 +10,11 @@ import _ from 'lodash';
 
 const debouncedFetchTextByBytePosition = _.debounce(
   (path, bytesToRead, nrOfLines) => {
-    fetchTextBasedOnByteFromScrollPosition(path, bytesToRead, nrOfLines);
+    fetchTextBasedOnByteFromScrollPosition(
+      path,
+      Math.round(bytesToRead),
+      nrOfLines
+    );
   },
   100
 );
@@ -197,12 +201,12 @@ const LogViewer = props => {
           // Slider base is 0 so we need to calculate logsize - sliderPosition in order to get the correct byte position.
           fetchTextBasedOnByteFromScrollPosition(
             props.source.path,
-            logSize - sliderPosition,
+            Math.round(logSize - sliderPosition),
             props.nrOfLinesInViewer
           );
           // Save timeout so it can be cleared if needed
-          setCurrentTimeout(timeout);
         }, 50);
+        setCurrentTimeout(timeout);
       }
     };
 


### PR DESCRIPTION
#472 

I noticed the scroller behaved weirldy/badly with track pads, and this was because of the timeout to cancel was set inside the function to be called after the timeout, meaning that there was never a timeout to cancel, resulting in many reads and strange behavior.  

The bytes to read seemed to end up as fractions of a byte, which caused the read to misbehave, so I rounded to bytes to the nearest integer before sending a read request, which should fix some issues.  

Sadly, scrolling with a track pad is now largely feedback-less, but I think this is better than what we had before.

Initial behavior when scrolling with (my) track pad:
![jankyscroll](https://user-images.githubusercontent.com/3668673/75157116-c76c9a80-5713-11ea-9c60-75c308a1acc3.gif)

Behavior when correctly rounding bytes, but sending a lot of read requests, slowing things down. Note that somewhere around the middle I started scrolling in the other direction, but it took a second or two before anything happened:
![slowscroll](https://user-images.githubusercontent.com/3668673/75157691-eddf0580-5714-11ea-8c60-9be54fe8f5d8.gif)

Behavior when not rounding the bytes to read. It's not terribly clear, but the displayed parts of the file seem to vary between the very end and the very start:
![buggedscroll](https://user-images.githubusercontent.com/3668673/75157422-5ed1ed80-5714-11ea-96f7-81d9a36a8437.gif)

And this is how it looks now. It's feels like it jumps around a lot, but I think this is the better solution for now. Scrolling is and issue we'll have to look at more in the future:
![fixedscroll](https://user-images.githubusercontent.com/3668673/75157899-56c67d80-5715-11ea-814a-d035b3f1a068.gif)