### PR TITLE
#459 Fix empty rows being displayed incorrectly

### DIFF
--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -56,7 +56,7 @@ const sendFileOpened = async (
 // Invisible character U+2800 being used in replace
 const replaceEmptyLinesWithHiddenChar = arr => {
   return arr.map(line => {
-    return line === '' ? line.replace('', '⠀') : line;
+    return line.replace('', '⠀');
   });
 };
 
@@ -69,6 +69,8 @@ const openFile = async (sender, filePath) => {
       endIndex,
       10
     );
+
+    //Lines in history that contains empty spaces does not display properly. replaceEmptyLinesWithHiddenChar(history) returns an array where this has been taken care of by replacing each space with a hidden character, and makes those lines display correctly in LogViewer.
     sendFileOpened(
       sender,
       filePath,

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -53,10 +53,15 @@ const sendFileOpened = async (
 
   sender.send(ipcChannel, action);
 };
-// Invisible character U+2800 being used in replace
+
+// Invisible character U+2800 being used in line.replace
 const replaceEmptyLinesWithHiddenChar = arr => {
+  const regexList = [/^\s*$/];
   return arr.map(line => {
-    return line.replace('', '⠀');
+    const isMatch = regexList.some(rx => {
+      rx.test(line);
+    });
+    return isMatch ? line.replace(regexList[0], '⠀') : line;
   });
 };
 

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -59,7 +59,7 @@ const replaceEmptyLinesWithHiddenChar = arr => {
   const regexList = [/^\s*$/];
   return arr.map(line => {
     const isMatch = regexList.some(rx => {
-      rx.test(line);
+      return rx.test(line);
     });
     return isMatch ? line.replace(regexList[0], '⠀') : line;
   });

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -53,6 +53,12 @@ const sendFileOpened = async (
 
   sender.send(ipcChannel, action);
 };
+// Invisible character U+2800 being used in replace
+const replaceEmptyLinesWithHiddenChar = arr => {
+  return arr.map(line => {
+    return line === '' ? line.replace('', '⠀') : line;
+  });
+};
 
 const openFile = async (sender, filePath) => {
   try {
@@ -68,7 +74,7 @@ const openFile = async (sender, filePath) => {
       filePath,
       fileSize,
       endIndex,
-      history,
+      replaceEmptyLinesWithHiddenChar(history),
       startByteOfLines
     );
   } catch (error) {
@@ -206,6 +212,7 @@ const readLinesStartingAtByte = async (sender, data) => {
   if (dataToReturn.lines.length > amountOfLines) {
     dataToReturn.lines = dataToReturn.lines.slice(0, amountOfLines);
   }
+  dataToReturn.lines = replaceEmptyLinesWithHiddenChar(dataToReturn.lines);
 
   const action = {
     type: 'LOGLINES_FETCHED_FROM_BYTEPOSITION',

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -42,9 +42,15 @@ const LogViewerList = props => {
     Math.round(props.containerHeight / characterDimensions.height)
   );
 
+  // Invisible character U+2800 being used in replace
+  const replaceEmptyLinesWithHiddenChar = () => {
+    return props.lines.map(line => {
+      return line === '' ? line.replace('', '⠀') : line;
+    });
+  };
   // Itemdata used to send needed props and state from this component to the pure component that renders a single line
   const itemData = createItemData(
-    props.lines,
+    replaceEmptyLinesWithHiddenChar(),
     props.highlightColor,
     logLineElementWidth,
     props.wrapLines
@@ -135,7 +141,10 @@ const LogViewerList = props => {
       <LogLineRuler ref={oneCharacterSizeRef}>
         <span>A</span>
       </LogLineRuler>
-      <List items={props.lines} onRenderCell={_onRenderCell} />
+      <List
+        items={replaceEmptyLinesWithHiddenChar()}
+        onRenderCell={_onRenderCell}
+      />
     </LogViewerListContainer>
   );
 };

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -42,15 +42,9 @@ const LogViewerList = props => {
     Math.round(props.containerHeight / characterDimensions.height)
   );
 
-  // Invisible character U+2800 being used in replace
-  const replaceEmptyLinesWithHiddenChar = () => {
-    return props.lines.map(line => {
-      return line === '' ? line.replace('', '⠀') : line;
-    });
-  };
   // Itemdata used to send needed props and state from this component to the pure component that renders a single line
   const itemData = createItemData(
-    replaceEmptyLinesWithHiddenChar(),
+    props.lines,
     props.highlightColor,
     logLineElementWidth,
     props.wrapLines
@@ -141,10 +135,7 @@ const LogViewerList = props => {
       <LogLineRuler ref={oneCharacterSizeRef}>
         <span>A</span>
       </LogLineRuler>
-      <List
-        items={replaceEmptyLinesWithHiddenChar()}
-        onRenderCell={_onRenderCell}
-      />
+      <List items={props.lines} onRenderCell={_onRenderCell} />
     </LogViewerListContainer>
   );
 };


### PR DESCRIPTION
Empty lines should be displayed correctly with props.lines going through a function before being assigned as itemData. Try it on your machine!