### PR TITLE
#462 Fix of empty page when scroll position is at the base 

### DIFF
--- a/src/js/view/components/CustomScrollBar.js
+++ b/src/js/view/components/CustomScrollBar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Slider } from 'office-ui-fabric-react';
 
 /*
-Custom scroll bar created from fabric-ui slider component.
+Custom scrollbar created from fabric-ui slider component.
 With this we are able to connect the position of the slider thumb to specific bytes in the file. 
 */
 
@@ -44,15 +44,15 @@ const CustomScrollBar = props => {
 
   return (
     <Slider
-      min={0}
-      max={props.logSize}
+      min={props.min}
+      max={props.max}
       onChange={value => {
         props.handleOnChange(value);
       }}
       showValue={false}
       step={props.step}
       styles={overrideStyles}
-      value={props.scrollPosition}
+      value={props.value}
       vertical
     />
   );

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -44,9 +44,11 @@ const LogViewer = props => {
   const lastSeenLogSize = props.lastSeenLogSizes[props.source.path];
 
   const [filteredAndHighlightedLines, setLines] = useState([]);
-  // Scroll position base is minScrollValue, top is logSize
-  const minScrollValue = 3000;
-  const [scrollPosition, setScrollPosition] = useState(minScrollValue);
+
+  // Scroll position base is minScrollValue, top is logSize.
+  // Calculating nrOfLinesInViewer * 100 in order to make the minimum value responsive to the resizing of the viewer.
+  const minScrollPositionValue = props.nrOfLinesInViewer * 100;
+  const [scrollPosition, setScrollPosition] = useState(minScrollPositionValue);
   const [currentTimeout, setCurrentTimeout] = useState();
   const [currentLogViewerContainerHeight, setCurrentContainerHeight] = useState(
     0
@@ -138,7 +140,7 @@ const LogViewer = props => {
 
       // Checking if the follow switch is on and if the log file is running.
       if (tailSwitch && logFileHasRunningStatus) {
-        setScrollPosition(minScrollValue);
+        setScrollPosition(minScrollPositionValue);
       }
     }
   }, [props.logs]);
@@ -149,7 +151,7 @@ const LogViewer = props => {
     const LINES_FROM_VIEWCONTAINER_BOTTOM = 5;
 
     if (logFileHasRunningStatus && tailSwitch) {
-      setScrollPosition(minScrollValue);
+      setScrollPosition(minScrollPositionValue);
       debouncedFetchTextByBytePosition(
         props.source.path,
         logSize - APPROXIMATE_AMOUNT_OF_BYTES_TO_FETCH,
@@ -172,8 +174,8 @@ const LogViewer = props => {
         let newScrollPosition = scrollPosition + event.deltaY;
         if (newScrollPosition > logSize) {
           newScrollPosition = logSize;
-        } else if (newScrollPosition <= minScrollValue) {
-          newScrollPosition = minScrollValue;
+        } else if (newScrollPosition <= minScrollPositionValue) {
+          newScrollPosition = minScrollPositionValue;
         }
 
         setScrollPosition(newScrollPosition);
@@ -199,7 +201,7 @@ const LogViewer = props => {
       clearTimeout(currentTimeout);
       // Set new timeout to read from file in an appropriate amount of time
       if (tailSwitch && logFileHasRunningStatus) {
-        setScrollPosition(minScrollValue);
+        setScrollPosition(minScrollPositionValue);
       } else {
         let timeout = setTimeout(() => {
           // Scroll base value is minScrollValue so we need to calculate logsize - scrollPosition in order to get the correct byte position.
@@ -231,7 +233,7 @@ const LogViewer = props => {
 
   const handleCustomScrollBarOnChange = value => {
     if (tailSwitch && logFileHasRunningStatus) {
-      setScrollPosition(minScrollValue);
+      setScrollPosition(minScrollPositionValue);
     } else {
       setScrollPosition(value);
       debouncedFetchTextByBytePosition(
@@ -259,7 +261,7 @@ const LogViewer = props => {
       <CustomScrollBar
         handleOnChange={handleCustomScrollBarOnChange}
         max={logSize}
-        min={minScrollValue}
+        min={minScrollPositionValue}
         value={scrollPosition}
         step={1}
       />

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -44,8 +44,9 @@ const LogViewer = props => {
   const lastSeenLogSize = props.lastSeenLogSizes[props.source.path];
 
   const [filteredAndHighlightedLines, setLines] = useState([]);
-  // Scroll position base is 0, top is logSize
-  const [scrollPosition, setScrollPosition] = useState(0);
+  // Scroll position base is minScrollValue, top is logSize
+  const minScrollValue = 3000;
+  const [scrollPosition, setScrollPosition] = useState(minScrollValue);
   const [currentTimeout, setCurrentTimeout] = useState();
   const [currentLogViewerContainerHeight, setCurrentContainerHeight] = useState(
     0
@@ -137,7 +138,7 @@ const LogViewer = props => {
 
       // Checking if the follow switch is on and if the log file is running.
       if (tailSwitch && logFileHasRunningStatus) {
-        setScrollPosition(0);
+        setScrollPosition(minScrollValue);
       }
     }
   }, [props.logs]);
@@ -148,7 +149,7 @@ const LogViewer = props => {
     const LINES_FROM_VIEWCONTAINER_BOTTOM = 5;
 
     if (logFileHasRunningStatus && tailSwitch) {
-      setScrollPosition(0);
+      setScrollPosition(minScrollValue);
       debouncedFetchTextByBytePosition(
         props.source.path,
         logSize - APPROXIMATE_AMOUNT_OF_BYTES_TO_FETCH,
@@ -171,8 +172,8 @@ const LogViewer = props => {
         let newScrollPosition = scrollPosition + event.deltaY;
         if (newScrollPosition > logSize) {
           newScrollPosition = logSize;
-        } else if (newScrollPosition <= 0) {
-          newScrollPosition = 0;
+        } else if (newScrollPosition <= minScrollValue) {
+          newScrollPosition = minScrollValue;
         }
 
         setScrollPosition(newScrollPosition);
@@ -198,10 +199,10 @@ const LogViewer = props => {
       clearTimeout(currentTimeout);
       // Set new timeout to read from file in an appropriate amount of time
       if (tailSwitch && logFileHasRunningStatus) {
-        setScrollPosition(0);
+        setScrollPosition(minScrollValue);
       } else {
         let timeout = setTimeout(() => {
-          // Slider base is 0 so we need to calculate logsize - sliderPosition in order to get the correct byte position.
+          // Scroll base value is minScrollValue so we need to calculate logsize - scrollPosition in order to get the correct byte position.
           fetchTextBasedOnByteFromScrollPosition(
             props.source.path,
             Math.round(logSize - scrollPosition),
@@ -230,7 +231,7 @@ const LogViewer = props => {
 
   const handleCustomScrollBarOnChange = value => {
     if (tailSwitch && logFileHasRunningStatus) {
-      setScrollPosition(0);
+      setScrollPosition(minScrollValue);
     } else {
       setScrollPosition(value);
       debouncedFetchTextByBytePosition(
@@ -257,8 +258,9 @@ const LogViewer = props => {
       </LogViewerContainer>
       <CustomScrollBar
         handleOnChange={handleCustomScrollBarOnChange}
-        logSize={logSize}
-        scrollPosition={scrollPosition}
+        max={logSize}
+        min={minScrollValue}
+        value={scrollPosition}
         step={1}
       />
     </LogViewerRootContainer>

--- a/src/js/view/reducers/logViewerReducer.test.js
+++ b/src/js/view/reducers/logViewerReducer.test.js
@@ -90,4 +90,62 @@ describe('logviewer reducer', () => {
     };
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });
+  it('should not replace lines when not following tail', () => {
+    const lines = ['hej4', 'hej5'];
+    const state = {
+      logs: { test: ['hej1', 'hej2', 'hej3'] },
+      nrOfLinesInViewer: 3
+    };
+    const expectedState = {
+      logs: { test: ['hej1', 'hej2', 'hej3', 'hej4', 'hej5'] },
+      nrOfLinesInViewer: 3
+    };
+    const sourcePath = 'test';
+    const followTail = false;
+    const action = {
+      type: 'LOGVIEWER_ADD_LINES',
+      data: { sourcePath, lines, followTail }
+    };
+    expect(logViewerReducer(state, action)).toEqual(expectedState);
+  });
+  it('should add lines and metadata from byte position to initial state', () => {
+    const lines = ['hej1', 'hej2'];
+    const sourcePath = 'test';
+    const startByteOfLines = [1, 2];
+    const state = {
+      logs: {},
+      startByteOfLines: {},
+      nrOfLinesInViewer: 2
+    };
+    const expectedState = {
+      logs: { test: ['hej1', 'hej2'] },
+      startByteOfLines: { test: [1, 2] },
+      nrOfLinesInViewer: 2
+    };
+    const action = {
+      type: 'LOGVIEWER_ADD_LINES_FETCHED_FROM_BYTE_POSITION',
+      data: { lines, sourcePath, startByteOfLines }
+    };
+    expect(logViewerReducer(state, action)).toEqual(expectedState);
+  });
+  it('should update the current number of lines in the viewer', () => {
+    const numberOfLinesToFillLogView = 10;
+    const state = {
+      logs: {},
+      startByteOfLines: {},
+      nrOfLinesInViewer: 5
+    };
+    const expectedState = {
+      logs: {},
+      startByteOfLines: {},
+      nrOfLinesInViewer: 10
+    };
+
+    const action = {
+      type: 'LOGVIEWER_UPDATE_CURRENT_NR_OF_LINES_IN_VIEWER',
+      data: { numberOfLinesToFillLogView }
+    };
+
+    expect(logViewerReducer(state, action)).toEqual(expectedState);
+  });
 });


### PR DESCRIPTION
This pull request contains one possible solution to the issue with scrolling past the last line scrolls way too far and shows an empty viewer. Along with some tests for the logViewerReducer.

Altering the minimum value of the slider displays a section of the file when scrolling to 0. With some space past the last line. I found it kind of nice to be able to scroll past it a bit.  
![image](https://user-images.githubusercontent.com/45069965/75331448-01a87a00-5883-11ea-99ba-efdf147d176c.png)

A pro is that the viewer can be very slim, or any size you want, and still display the end of the file when the scroll is at the base. 
![image](https://user-images.githubusercontent.com/45069965/75331733-872c2a00-5883-11ea-8621-5730225d2e6e.png)

However, a con is when encountering logfiles with longer lines, the amount of blank space covers more of the viewer. Still works but maybe not very consistent.
![image](https://user-images.githubusercontent.com/45069965/75331595-4502e880-5883-11ea-8022-ed39e44de938.png)

Please let me know if you think this would work for now, if something could be changed or if we should wait on figuring this issue out until we for example have the file cache in place. Maybe that could help solve it in a better way(?)