### PR TITLE
Fix initial scroll position #463

### DIFF
--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -142,6 +142,10 @@ const LogViewer = props => {
   }, []);
 
   useEffect(() => {
+    setScrollPosition(minScrollPositionValue);
+  }, [minScrollPositionValue]);
+
+  useEffect(() => {
     /* Effect for when a new filter or highlight is applied,
     send the lines to be filtered and highlighted again */
     if (props.logs[props.source.path]) {


### PR DESCRIPTION
Adding an effect to catch the update of the minScrollPosition value and set it as the scroll position seems to take away the big jump the scroll makes when scrolling upwards for the first time. 

The 'jump' from the initial set of lines (10) to the first fetched list of lines, which has a calculation based on the number of lines in the viewer, is still there. I was not sure if this issue covers that as well. 
I suspect that the correct amount of initial lines to display will be easier to fix once the cache is implemented.

What do you think?