### PR TITLE
BUG: Scrollpositionen är inte individuell för varje tabb. #483

### DIFF
--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -230,3 +230,15 @@ export const updateNumberOfLinesToRenderInLogView = (
     data: { numberOfLinesToFillLogView }
   });
 };
+
+//updateScrollPosition action used to update scrollPosition on each log in independent way with other logs.
+export const updateScrollPosition = (
+  dispatch, 
+  sourcePath, 
+  scrollPosition
+  ) => {
+    dispatch({
+      type: 'LOGVIEWER_UPDATE_SCROLL_POSITION',
+      data: { sourcePath, scrollPosition }
+    });
+};

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -3,7 +3,8 @@ const initialState = {
   startByteOfLines: {},
   nrOfLinesInViewer: null,
   meanByteValuesOfInitialLines: {},
-  meanByteValuesOfLines: {}
+  meanByteValuesOfLines: {},
+  scrollPositions: {}
 };
 
 const calculateMeanValueOfBytesPerLine = startBytes => {
@@ -115,6 +116,19 @@ export const logViewerReducer = (state = initialState, action) => {
       return {
         ...state,
         nrOfLinesInViewer: numberOfLinesToFillLogView
+      };
+    }
+
+    //updateScrollPosition action passed by Reducer
+    case 'LOGVIEWER_UPDATE_SCROLL_POSITION': {
+      const { sourcePath, scrollPosition } = action.data;
+
+      return {
+        ...state,
+        scrollPositions: {
+          ...state.scrollPositions,
+          [sourcePath]: scrollPosition
+        }
       };
     }
 


### PR DESCRIPTION
The bug has been fixed by using scrollPosition instead local state in redux, we bring scrollPosition value which we saved in Reducer then implemented it in logViewer by using updateScrollPosition function instead setScrollPosition function inside useEffect hook instead useState hook.