### PR TITLE
Logfile review activity icon instead the orange point

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16152,6 +16152,14 @@
         "inherits": "^2.0.1"
       }
     },
+    "rmdi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rmdi/-/rmdi-1.0.1.tgz",
+      "integrity": "sha512-1oxFIH6/mZrw6HN6M0PCogMf783FUKOD2tZW5HyX+Ok6nUodd4kob2UvzzFtaEx7GuD8KzaQPid/pbFjO5D7uw==",
+      "requires": {
+        "styled-system": "^2.0.0"
+      }
+    },
     "roarr": {
       "version": "2.15.2",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
@@ -17303,6 +17311,14 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "styled-system": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-2.3.6.tgz",
+      "integrity": "sha512-lGAh/8tC70f5hBUD7w0UOWCKyOBK2AzzWKu9BGzqla/Yjx8PzrvaciA7uATbm493hXTfRrecSdLdrIUET5IYnA==",
+      "requires": {
+        "prop-types": "^15.6.0"
       }
     },
     "stylehacks": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-scripts": "^3.3.0",
     "react-tooltip": "^3.11.2",
     "redux": "^4.0.5",
-    "rmdi": "^1.0.1",
     "styled-components": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-scripts": "^3.3.0",
     "react-tooltip": "^3.11.2",
     "redux": "^4.0.5",
+    "rmdi": "^1.0.1",
     "styled-components": "^5.0.0"
   },
   "devDependencies": {

--- a/src/js/view/components/TabPanelContainer.js
+++ b/src/js/view/components/TabPanelContainer.js
@@ -16,6 +16,7 @@ import {
 import { closeFile, showOpenDialog } from './helpers/handleFileHelper';
 import Mousetrap from 'mousetrap';
 import { Stack, IconButton } from 'office-ui-fabric-react';
+import ArrowDownward from 'rmdi/lib/ArrowDownward';
 
 /**
  * Helper function to get actual modulo operation, as %-operator doesn't quite fit the bill
@@ -172,7 +173,10 @@ function customRenderer(
               openSources[source].index === currentSourceHandle ? true : false
             }
             activity={logSize !== lastSeenLogSize ? true : false}
-          />
+            viewBox="0 0 80 80"
+          >
+            <ArrowDownward size={80} color="#2e86de" />
+          </Indicator>
         </div>
       </span>
     );

--- a/src/js/view/components/TabPanelContainer.js
+++ b/src/js/view/components/TabPanelContainer.js
@@ -15,8 +15,12 @@ import {
 } from '../actions/dispatchActions';
 import { closeFile, showOpenDialog } from './helpers/handleFileHelper';
 import Mousetrap from 'mousetrap';
-import { Stack, IconButton } from 'office-ui-fabric-react';
-import ArrowDownward from 'rmdi/lib/ArrowDownward';
+import {
+  Spinner,
+  SpinnerSize,
+  Stack,
+  IconButton
+} from 'office-ui-fabric-react';
 
 /**
  * Helper function to get actual modulo operation, as %-operator doesn't quite fit the bill
@@ -159,24 +163,35 @@ function customRenderer(
     return (
       <span>
         {defaultRenderer(link)}
-        <div style={{ display: 'inline' }}>
-          <div
-            onClick={event => {
-              exitLog(openSources[source].path, event);
-            }}
-            style={{ display: 'inline-block', marginLeft: '10px' }}
-          >
-            <Icon iconName="Cancel" />
-          </div>
+        <div
+          style={{
+            display: 'inline'
+          }}
+        >
           <Indicator
             selected={
               openSources[source].index === currentSourceHandle ? true : false
             }
             activity={logSize !== lastSeenLogSize ? true : false}
-            viewBox="0 0 80 80"
           >
-            <ArrowDownward size={80} color="#2e86de" />
+            <Spinner
+              size={SpinnerSize.small}
+              styles={{
+                circle: {
+                  borderColor: '#B2DFDB',
+                  borderRightColor: '#00796B'
+                }
+              }}
+            />
           </Indicator>
+        </div>
+        <div
+          onClick={event => {
+            exitLog(openSources[source].path, event);
+          }}
+          style={{ display: 'inline-block', marginLeft: '15px' }}
+        >
+          <Icon iconName="Cancel" />
         </div>
       </span>
     );

--- a/src/js/view/styledComponents/TabPanelStyledComponent.js
+++ b/src/js/view/styledComponents/TabPanelStyledComponent.js
@@ -1,31 +1,10 @@
 import styled from 'styled-components';
 
-export const Indicator = styled.svg`
-  -webkit-animation: action 0.6s infinite alternate;
-  animation: action 0.6s infinite alternate;
-  margin: -10px 0 0 -10px;
-  width: 20px;
-  height: 20x;
+export const Indicator = styled.div`
   display: inline-block;
   position: relative;
-  top: 2px;
-  left: 14px;
-  @-webkit-keyframes action {
-    0% {
-      transform: translateY(0);
-    }
-    100% {
-      transform: translateY(-5px);
-    }
-  }
-  @keyframes action {
-    0% {
-      transform: translateY(0);
-    }
-    100% {
-      transform: translateY(-3px);
-    }
-  }
+  top: -1px;
+  left: 8px;
   opacity: ${props => {
     let opacity = 0;
     if (!props.selected && props.activity) {

--- a/src/js/view/styledComponents/TabPanelStyledComponent.js
+++ b/src/js/view/styledComponents/TabPanelStyledComponent.js
@@ -1,15 +1,31 @@
 import styled from 'styled-components';
 
-export const Indicator = styled.div`
-  width: 10px;
-  height: 10px;
+export const Indicator = styled.svg`
+  -webkit-animation: action 0.6s infinite alternate;
+  animation: action 0.6s infinite alternate;
+  margin: -10px 0 0 -10px;
+  width: 20px;
+  height: 20x;
   display: inline-block;
-  background-color: orange;
-  border-radius: 50%;
   position: relative;
-  top: -3px;
-  left: 2px;
-  border: grey solid 1px;
+  top: 2px;
+  left: 14px;
+  @-webkit-keyframes action {
+    0% {
+      transform: translateY(0);
+    }
+    100% {
+      transform: translateY(-5px);
+    }
+  }
+  @keyframes action {
+    0% {
+      transform: translateY(0);
+    }
+    100% {
+      transform: translateY(-3px);
+    }
+  }
   opacity: ${props => {
     let opacity = 0;
     if (!props.selected && props.activity) {


### PR DESCRIPTION
Updated logfile review activity orange point into more significant icon which is an Up/Down Arrow displays that the current log in review activity state and the number of lines increasing. The new icon is more significant than the orange point. Also the color of the new icon is regular with UI Design.
I implemented different icons as shown in the attached PoC, you can choose which one is better, either if i have to keep this Up/Down Arrow, either the loading circle, or if i have to change to color into orange or other colors.
<img width="854" alt="Screenshot 2020-03-24 at 10 03 52" src="https://user-images.githubusercontent.com/20910264/77469090-ddeb3c00-6e0e-11ea-90d5-ade751b8284d.png">
<img width="851" alt="Screenshot 2020-03-24 at 09 58 52" src="https://user-images.githubusercontent.com/20910264/77469276-1c80f680-6e0f-11ea-9faf-8d740c64dd25.png">
