### PR TITLE
Implement fabric-ui color picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-scripts": "^3.3.0",
     "react-tooltip": "^3.11.2",
     "redux": "^4.0.5",
-    "rmdi": "^1.0.1",
     "styled-components": "^5.0.0"
   },
   "devDependencies": {

--- a/src/js/view/components/TabSettings.js
+++ b/src/js/view/components/TabSettings.js
@@ -5,7 +5,12 @@ import {
   handleHighlightColor,
   handleWrapLineOn
 } from '../actions/dispatchActions';
-import { Stack, IconButton, Label, ColorPicker } from 'office-ui-fabric-react';
+import {
+  Stack,
+  IconButton,
+  Label,
+  SwatchColorPicker
+} from 'office-ui-fabric-react';
 
 const { Component } = require('react');
 const React = require('react');
@@ -16,6 +21,23 @@ const stackTokens = {
 };
 
 class TabSettings extends Component {
+  _menuButtonElement = React.createRef();
+  state = {
+    isCalloutVisible: false
+  };
+
+  _onShowMenuClicked = () => {
+    this.setState({
+      isCalloutVisible: !this.state.isCalloutVisible
+    });
+  };
+
+  _onCalloutDismiss = () => {
+    this.setState({
+      isCalloutVisible: false
+    });
+  };
+
   render() {
     const sourcePath = this.props.openSources[this.props.currentSourceHandle]
       .path;
@@ -34,27 +56,42 @@ class TabSettings extends Component {
       <Stack horizontal horizontalAlign="space-between">
         <Stack horizontal tokens={stackTokens}>
           <Stack.Item>
-            <Label>Color for highlights</Label>
-            <ColorPicker
-              color={highlightColor}
-              onChange={(e, colorObj) => {
-                handleHighlightColor(this.props.dispatch, {
-                  color: colorObj.str,
-                  sourcePath
-                });
-              }}
-            />
+            <Label style={{ paddingLeft: '5.5px' }}>Color for highlights</Label>
+            <div>
+              <SwatchColorPicker
+                columnCount={5}
+                cellShape={'circle'}
+                colorCells={[
+                  { id: 'a', label: 'red', color: '#a4262c' },
+                  { id: 'a', label: 'orange', color: '#ca5010' },
+                  { id: 'f', label: 'cyan', color: '#038387' },
+                  { id: 'c', label: 'blueMagenta', color: '#8764b8' },
+                  { id: 'g', label: 'cyanBlue', color: '#004e8c' }
+                ]}
+                selectedId={highlightColor}
+                cellHeight={35}
+                cellWidth={35}
+                onColorChanged={(e, clr) => {
+                  handleHighlightColor(this.props.dispatch, {
+                    color: clr,
+                    sourcePath
+                  });
+                }}
+              />
+            </div>
           </Stack.Item>
           <Stack.Item>
             <Label>Wrap Lines</Label>
-            <SwitchButton
-              checked={wrapLineOn}
-              onChange={() => {
-                handleWrapLineOn(this.props.dispatch, { sourcePath });
-              }}
-              onText="On"
-              offText="Off"
-            />
+            <div style={{ paddingTop: '13px' }}>
+              <SwitchButton
+                checked={wrapLineOn}
+                onChange={() => {
+                  handleWrapLineOn(this.props.dispatch, { sourcePath });
+                }}
+                onText="On"
+                offText="Off"
+              />
+            </div>
           </Stack.Item>
         </Stack>
         <Stack tokens={stackTokens}>

--- a/src/js/view/components/TabSettings.js
+++ b/src/js/view/components/TabSettings.js
@@ -1,12 +1,11 @@
 import { connect } from 'react-redux';
-import { GithubPicker } from 'react-color';
 import { SwitchButton } from 'js/view/components/common/buttons';
 import {
   handleShowSettings,
   handleHighlightColor,
   handleWrapLineOn
 } from '../actions/dispatchActions';
-import { Stack, IconButton, Label } from 'office-ui-fabric-react';
+import { Stack, IconButton, Label, ColorPicker } from 'office-ui-fabric-react';
 
 const { Component } = require('react');
 const React = require('react');
@@ -36,12 +35,11 @@ class TabSettings extends Component {
         <Stack horizontal tokens={stackTokens}>
           <Stack.Item>
             <Label>Color for highlights</Label>
-            <GithubPicker
+            <ColorPicker
               color={highlightColor}
-              triangle={'hide'}
-              onChangeComplete={e => {
+              onChange={(e, colorObj) => {
                 handleHighlightColor(this.props.dispatch, {
-                  color: e.hex,
+                  color: colorObj.str,
                   sourcePath
                 });
               }}

--- a/src/js/view/styledComponents/TextHighlightRegexStyledComponents.js
+++ b/src/js/view/styledComponents/TextHighlightRegexStyledComponents.js
@@ -13,19 +13,27 @@ export const Settings = styled.div`
 `;
 
 const matchingTextColor = {
-  '#b80000': '#eeefea',
-  '#db3e00': '#eeefea',
-  '#008b02': '#eeefea',
-  '#006b76': '#eeefea',
-  '#1273de': '#eeefea',
-  '#004dcf': '#eeefea',
-  '#5300eb': '#eeefea',
+  '#a4262c': '#222',
+  '#ca5010': '#222',
+  '#038387': '#222',
+  '#8764b8': '#222',
+  '#004e8c': '#222',
   default: '#222'
+};
+
+const backgroundColor = {
+  '#a4262c': '#a4262c',
+  '#ca5010': '#ca5010',
+  '#038387': '#038387',
+  '#8764b8': '#8764b8',
+  '#004e8c': '#004e8c',
+  default: '#a4262c'
 };
 
 export const HighlightText = styled.span`
   background: ${props => {
-    return props.color;
+    const bgColor = backgroundColor[props.color];
+    return bgColor ? bgColor : backgroundColor.default;
   }};
   color: ${props => {
     const textColor = matchingTextColor[props.color];


### PR DESCRIPTION
Implemented Fabric UI ColorPicker instead of Github ColorPicker, now the user has all RGB colors to use.
<img width="827" alt="Screenshot 2020-03-31 at 17 53 57" src="https://user-images.githubusercontent.com/20910264/78047446-a33a5400-7378-11ea-89df-6b2eae587cbd.png">
<img width="676" alt="Screenshot 2020-03-31 at 17 54 26" src="https://user-images.githubusercontent.com/20910264/78047511-b9e0ab00-7378-11ea-8307-807d7a7143e6.png">

