### PR TITLE
#450 Wrap Lines not visible upon start

### DIFF
--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -26,6 +26,9 @@ const LogViewerList = props => {
   const [maxLineLength, setCurrentMaxLineLength] = useState(1); // Used to save and update how many characters the longest line has
   const [lastLineCount, setLastLineCount] = useState(0); // Used to keep track of how many lines there were last render, for optimizing mainly calculation of new lines
 
+  //listRef is used to get the reference to the List object so that we can use its method forceUpdate
+  const listRef = useRef();
+
   const logViewerListContainerRef = useRef();
   const [listDimensions, setListDimensions] = useState({
     width: 575,
@@ -130,8 +133,6 @@ const LogViewerList = props => {
     );
   };
 
-  //listRef is used to get the reference to the List object so that we can use its method forceUpdate
-  const listRef = useRef();
   //Force updates the List when wrapLines changes value
   useEffect(() => {
     listRef.current.forceUpdate();

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -130,12 +130,19 @@ const LogViewerList = props => {
     );
   };
 
+  //listRef is used to get the reference to the List object so that we can use its method forceUpdate
+  const listRef = useRef();
+  //Force updates the List when wrapLines changes value
+  useEffect(() => {
+    listRef.current.forceUpdate();
+  }, [props.wrapLines]);
+
   return (
     <LogViewerListContainer ref={logViewerListContainerRef}>
       <LogLineRuler ref={oneCharacterSizeRef}>
         <span>A</span>
       </LogLineRuler>
-      <List items={props.lines} onRenderCell={_onRenderCell} />
+      <List items={props.lines} onRenderCell={_onRenderCell} ref={listRef} />
     </LogViewerListContainer>
   );
 };


### PR DESCRIPTION
Toggling the wrap line on or off now triggers a re-render instantly.

The problem:
The prop change that happened when Wrap Line was toggled did not fire a re-render of the List.

Possible reason why:
The List element (used in LogViewerList) was only rendering the log lines upon a render call of itself (used via its prop onRenderCell), and the prop that changed was only listened to by the log line elements, hence it did not see any change and therefore it did not re-render.

The fix:
By creating a reference to the List object it was possible to use its forceUpdate-method to make it re-render itself when the prop changed.