### PR TITLE
#474 Background of files with long lines are set to the wrong size

### DIFF
--- a/src/js/hiddenWindow/mainScriptOffloader.js
+++ b/src/js/hiddenWindow/mainScriptOffloader.js
@@ -53,14 +53,12 @@ class LogsFiltererAndHighlighter {
                 text: value,
                 highlightSection: this.highlightRegex.test(value)
               };
-            }),
-            length: line.length
+            })
           };
         } else {
           lineObj = {
             highlightLine: false,
-            sections: [{ text: line, highlightSection: false }],
-            length: line.length
+            sections: [{ text: line, highlightSection: false }]
           };
         }
 

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -135,7 +135,11 @@ const LogViewerList = props => {
       <LogLineRuler ref={oneCharacterSizeRef}>
         <span>A</span>
       </LogLineRuler>
-      <List items={props.lines} onRenderCell={_onRenderCell} />
+      <List
+        style={{ display: 'inline-block', minWidth: '100%' }}
+        items={props.lines}
+        onRenderCell={_onRenderCell}
+      />
     </LogViewerListContainer>
   );
 };

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -52,7 +52,7 @@ const LogViewerList = props => {
     listRef.current.forceUpdate();
   }, [props.wrapLines]);
 
-  // Measure is a component that is used to measure the height of a character
+  // Measure is used to measure the height of a character
   const Measure = ({ onMeasured }) => {
     const oneCharacterRef = useRef();
 
@@ -68,7 +68,6 @@ const LogViewerList = props => {
       <SingleLogLineTranslator
         data={itemData}
         index={index}
-        style={{ willChange: 'unset' }}
       ></SingleLogLineTranslator>
     );
   };

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -10,31 +10,19 @@ import { updateNumberOfLinesToRenderInLogView } from '../actions/dispatchActions
 import _ from 'lodash';
 import { List } from 'office-ui-fabric-react';
 
-const createItemData = memoize(
-  (lines, highlightColor, elementWidth, shouldWrap) => {
-    return {
-      lines,
-      highlightColor,
-      elementWidth,
-      shouldWrap
-    };
-  }
-);
+const createItemData = memoize((lines, highlightColor, shouldWrap) => {
+  return {
+    lines,
+    highlightColor,
+    shouldWrap
+  };
+});
 
 const LogViewerList = props => {
-  const [logLineElementWidth, setLogLineElementWidth] = useState(1); // Used to save and set the width the LogLine elements should be
-  const [maxLineLength, setCurrentMaxLineLength] = useState(1); // Used to save and update how many characters the longest line has
-  const [lastLineCount, setLastLineCount] = useState(0); // Used to keep track of how many lines there were last render, for optimizing mainly calculation of new lines
-
   const logViewerListContainerRef = useRef();
-  const [listDimensions, setListDimensions] = useState({
-    width: 575,
-    height: 145
-  });
 
   const oneCharacterSizeRef = useRef();
   const [characterDimensions, setCharacterDimensions] = useState({
-    width: 10,
     height: 19
   });
 
@@ -46,20 +34,13 @@ const LogViewerList = props => {
   const itemData = createItemData(
     props.lines,
     props.highlightColor,
-    logLineElementWidth,
     props.wrapLines
   );
 
   useEffect(() => {
     // Handler to update the dimensions when needed
     const handleResize = () => {
-      setListDimensions({
-        width: logViewerListContainerRef.current.offsetWidth,
-        height: logViewerListContainerRef.current.offsetHeight
-      });
-
       setCharacterDimensions({
-        width: oneCharacterSizeRef.current.offsetWidth,
         height: oneCharacterSizeRef.current.offsetHeight
       });
     };
@@ -73,38 +54,6 @@ const LogViewerList = props => {
       window.removeEventListener('resize', debouncedResizeHandler);
     };
   }, []);
-
-  useEffect(() => {
-    // Update the width to use for the list to fit the longest line if wraplines isn't set
-    setLogLineElementWidth(
-      props.wrapLines
-        ? listDimensions.width
-        : maxLineLength * characterDimensions.width
-    );
-  }, [
-    props.wrapLines,
-    maxLineLength,
-    listDimensions.width,
-    characterDimensions.width
-  ]);
-
-  useEffect(() => {
-    let currentMaxLength = maxLineLength;
-    let index = lastLineCount;
-    for (; index < props.lines.length; index++) {
-      // Remove all of the stuff hiddenWindow has added to it, as they shouldn't count towards the length of the string
-      let lineWithoutExtrasLength = props.lines[index].replace(
-        /\[\/?HL[LG\d]+\]/g,
-        ''
-      ).length;
-      if (lineWithoutExtrasLength > currentMaxLength) {
-        currentMaxLength = lineWithoutExtrasLength;
-      }
-    }
-
-    setCurrentMaxLineLength(currentMaxLength);
-    setLastLineCount(index);
-  }, [props.lines]);
 
   useEffect(() => {
     // Calculating the amount of lines needed to fill the page in the logviewer

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -19,12 +19,13 @@ const createItemData = memoize((lines, highlightColor, shouldWrap) => {
 });
 
 const LogViewerList = props => {
+  const [measuredCharHeight, setMeasuredCharHeight] = useState(null);
+
   //listRef is used to call upon forceUpdate on the List object when wrap lines is toggled
   const listRef = useRef();
 
   const logViewerListContainerRef = useRef();
 
-  const oneCharacterSizeRef = useRef();
   const [characterDimensions, setCharacterDimensions] = useState({
     height: 19
   });
@@ -40,11 +41,22 @@ const LogViewerList = props => {
     props.wrapLines
   );
 
+  // Measure is a component that is used to measure the height of a character
+  const Measure = ({ onMeasured }) => {
+    const oneCharacterRef = useRef();
+
+    useEffect(() => {
+      onMeasured(oneCharacterRef.current.offsetHeight);
+    }, [onMeasured, oneCharacterRef]);
+
+    return <LogLineRuler ref={oneCharacterRef}>A</LogLineRuler>;
+  };
+
   useEffect(() => {
     // Handler to update the dimensions when needed
     const handleResize = () => {
       setCharacterDimensions({
-        height: oneCharacterSizeRef.current.offsetHeight
+        height: measuredCharHeight
       });
     };
     handleResize();
@@ -61,8 +73,9 @@ const LogViewerList = props => {
   useEffect(() => {
     // Calculating the amount of lines needed to fill the page in the logviewer
     setNumberOfLinesToFillLogView(
-      Math.round(props.containerHeight / characterDimensions.height)
+      Math.round(props.containerHeight / measuredCharHeight)
     );
+    console.log(`Measure: ${measuredCharHeight}`);
   }, [props.containerHeight, characterDimensions]);
 
   useEffect(() => {
@@ -89,9 +102,7 @@ const LogViewerList = props => {
 
   return (
     <LogViewerListContainer ref={logViewerListContainerRef}>
-      <LogLineRuler ref={oneCharacterSizeRef}>
-        <span>A</span>
-      </LogLineRuler>
+      {!measuredCharHeight && <Measure onMeasured={setMeasuredCharHeight} />}
       <List
         ref={listRef}
         items={props.lines}

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -7,7 +7,6 @@ import {
 } from '../styledComponents/LogViewerListStyledComponents';
 import SingleLogLineTranslator from './SingleLogLine';
 import { updateNumberOfLinesToRenderInLogView } from '../actions/dispatchActions';
-import _ from 'lodash';
 import { List } from 'office-ui-fabric-react';
 
 const createItemData = memoize((lines, highlightColor, shouldWrap) => {
@@ -20,19 +19,10 @@ const createItemData = memoize((lines, highlightColor, shouldWrap) => {
 
 const LogViewerList = props => {
   const [measuredCharHeight, setMeasuredCharHeight] = useState(null);
+  const [nbrOfLinesToFillLogView, setNbrOfLinesToFillLogView] = useState(null);
 
   //listRef is used to call upon forceUpdate on the List object when wrap lines is toggled
   const listRef = useRef();
-
-  const logViewerListContainerRef = useRef();
-
-  const [characterDimensions, setCharacterDimensions] = useState({
-    height: 19
-  });
-
-  const [numberOfLinesToFillLogView, setNumberOfLinesToFillLogView] = useState(
-    Math.round(props.containerHeight / characterDimensions.height)
-  );
 
   // Itemdata used to send needed props and state from this component to the pure component that renders a single line
   const itemData = createItemData(
@@ -53,37 +43,18 @@ const LogViewerList = props => {
   };
 
   useEffect(() => {
-    // Handler to update the dimensions when needed
-    const handleResize = () => {
-      setCharacterDimensions({
-        height: measuredCharHeight
-      });
-    };
-    handleResize();
-
-    // Calls are throttled to once every 200 ms
-    const debouncedResizeHandler = _.debounce(handleResize, 200);
-    window.addEventListener('resize', debouncedResizeHandler);
-    // Return cleanup function
-    return () => {
-      window.removeEventListener('resize', debouncedResizeHandler);
-    };
-  }, []);
-
-  useEffect(() => {
     // Calculating the amount of lines needed to fill the page in the logviewer
-    setNumberOfLinesToFillLogView(
+    setNbrOfLinesToFillLogView(
       Math.round(props.containerHeight / measuredCharHeight)
     );
-    console.log(`Measure: ${measuredCharHeight}`);
-  }, [props.containerHeight, characterDimensions]);
+  }, [props.containerHeight, measuredCharHeight]);
 
   useEffect(() => {
     updateNumberOfLinesToRenderInLogView(
       props.dispatcher,
-      numberOfLinesToFillLogView
+      nbrOfLinesToFillLogView
     );
-  }, [numberOfLinesToFillLogView]);
+  }, [nbrOfLinesToFillLogView]);
 
   useEffect(() => {
     //Force updates the List when the user toggles Wrap Lines
@@ -101,7 +72,7 @@ const LogViewerList = props => {
   };
 
   return (
-    <LogViewerListContainer ref={logViewerListContainerRef}>
+    <LogViewerListContainer>
       {!measuredCharHeight && <Measure onMeasured={setMeasuredCharHeight} />}
       <List
         ref={listRef}

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -31,17 +31,6 @@ const LogViewerList = props => {
     props.wrapLines
   );
 
-  // Measure is a component that is used to measure the height of a character
-  const Measure = ({ onMeasured }) => {
-    const oneCharacterRef = useRef();
-
-    useEffect(() => {
-      onMeasured(oneCharacterRef.current.offsetHeight);
-    }, [onMeasured, oneCharacterRef]);
-
-    return <LogLineRuler ref={oneCharacterRef}>A</LogLineRuler>;
-  };
-
   useEffect(() => {
     // Calculating the amount of lines needed to fill the page in the logviewer
     setNbrOfLinesToFillLogView(
@@ -60,6 +49,17 @@ const LogViewerList = props => {
     //Force updates the List when the user toggles Wrap Lines
     listRef.current.forceUpdate();
   }, [props.wrapLines]);
+
+  // Measure is a component that is used to measure the height of a character
+  const Measure = ({ onMeasured }) => {
+    const oneCharacterRef = useRef();
+
+    useEffect(() => {
+      onMeasured(oneCharacterRef.current.offsetHeight);
+    }, [onMeasured, oneCharacterRef]);
+
+    return <LogLineRuler ref={oneCharacterRef}>A</LogLineRuler>;
+  };
 
   const _onRenderCell = (item, index) => {
     return (

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -34,7 +34,9 @@ const LogViewerList = props => {
   useEffect(() => {
     // Calculating the amount of lines needed to fill the page in the logviewer
     setNbrOfLinesToFillLogView(
-      Math.round(props.containerHeight / measuredCharHeight)
+      measuredCharHeight
+        ? Math.round(props.containerHeight / measuredCharHeight)
+        : null
     );
   }, [props.containerHeight, measuredCharHeight]);
 

--- a/src/js/view/components/SingleLogLine.js
+++ b/src/js/view/components/SingleLogLine.js
@@ -37,7 +37,6 @@ const SingleLogLineTranslator = React.memo(({ data, index, style }) => {
       style={style}
       line={line}
       highlightColor={data.highlightColor}
-      elementWidth={data.elementWidth}
       shouldWrap={data.shouldWrap}
       index={index}
     ></MemoedSingleLogLine>

--- a/src/js/view/components/SingleLogLine.js
+++ b/src/js/view/components/SingleLogLine.js
@@ -19,7 +19,7 @@ const MemoedSingleLogLine = React.memo(props => {
       {/^\[HLL\].*\[\/HLL\]$/.test(props.line) ? (
         <TextHighlightRegex text={props.line} color={props.highlightColor} />
       ) : (
-        props.line
+        <span>{props.line}</span>
       )}
     </LogLine>
   );

--- a/src/js/view/components/SingleLogLine.js
+++ b/src/js/view/components/SingleLogLine.js
@@ -11,8 +11,7 @@ const MemoedSingleLogLine = React.memo(props => {
   return (
     <LogLine
       style={{
-        ...props.style,
-        width: props.elementWidth + 'px'
+        ...props.style
       }}
       wrap={props.shouldWrap ? 'true' : undefined}
       index={props.index}
@@ -20,7 +19,7 @@ const MemoedSingleLogLine = React.memo(props => {
       {/^\[HLL\].*\[\/HLL\]$/.test(props.line) ? (
         <TextHighlightRegex text={props.line} color={props.highlightColor} />
       ) : (
-        <span>{props.line}</span>
+        props.line
       )}
     </LogLine>
   );

--- a/src/js/view/styledComponents/LogViewerListStyledComponents.js
+++ b/src/js/view/styledComponents/LogViewerListStyledComponents.js
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
 export const LogViewerListContainer = styled.div`
-  width: 100%;
+  min-width: 100%;
   height: 100%;
+  display: inline-block;
 `;
 
 export const LogLine = styled.div`


### PR DESCRIPTION
The background in the log viewer is now as wide as the container itself or as wide as the longest line.

The problem:
When opening a file that contained one or more wider lines than the view was you could see that the background was not as wide as the longest line. Directly opening a new log file with lines shorter than the container would reveal that the size was still wrong but this time it had the width of the old log file. 

The solution:
The first part was to remove that we set the width manually in the styling of the Log Line-element. Not only did this calculated width come out wrong, it was not necessary since it could be solved with the right CSS code. With the styling 'display: inline-block' and 'min-width: 100%' on the fabric ui List that contained the Log Lines, the right behaviour was achieved. Now the width of all the divs inside the Log Viewer Container are the same, either as wide as the view or as wide as the current longest line.

Note that there are a lot of code removed since a lot of it had to do with calculating the width of the longest line. A lot of the effect hooks relied upon states updated by other effect hooks and they all had some parts in calculating the width and height of a line. There were also a div with a span and the letter 'A' hidden in the CSS code that was used to calculate the height of the font used. I took this opportunity to change the code of measuring this so that the resulting CSS didn't have this div and span left in its code.