### PR TITLE
#505 Fix follow tail behaviour 

### DIFF
--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -237,12 +237,20 @@ const getNewLinesFromCache = async (sender, data) => {
   }
 
   const newLines = cache.lines;
+  const startBytes = cache.startsAtByte;
+  const byteForLineBreak = 2;
+  const isEndOfFile =
+    Buffer.byteLength(newLines[newLines.length - 1], 'utf8') +
+      startBytes[startBytes.length - 1] +
+      byteForLineBreak >=
+    fileSize;
 
   // Send result to frontend
   const dataToReturn = {
     sourcePath,
     newLines,
-    indexForNewLines
+    indexForNewLines,
+    isEndOfFile
   };
   const action = {
     type: 'LOGLINES_FETCHED_FROM_BACKEND_CACHE',

--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -162,13 +162,12 @@ export const hideSnackBar = dispatch => {
   });
 };
 
-export const addNewLines = (dispatch, sourcePath, lines, followTail) => {
+export const addNewLines = (dispatch, sourcePath, lines) => {
   dispatch({
     type: 'LOGVIEWER_ADD_LINES',
     data: {
       sourcePath,
-      lines,
-      followTail
+      lines
     }
   });
 };
@@ -197,14 +196,16 @@ export const addLinesFetchedFromBackendCache = (
   dispatch,
   sourcePath,
   newLines,
-  indexForNewLines
+  indexForNewLines,
+  isEndOfFile
 ) => {
   dispatch({
     type: 'LOGVIEWER_ADD_LINES_FETCHED_FROM_BACKEND_CACHE',
     data: {
       sourcePath,
       newLines,
-      indexForNewLines
+      indexForNewLines,
+      isEndOfFile
     }
   });
 };

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -153,14 +153,6 @@ const LogViewer = props => {
   }, [props.source.path]);
 
   useEffect(() => {
-    saveCurrentScrollTop(props.dispatch, props.source.path, currentScrollTop);
-  }, [currentScrollTop]);
-
-  useEffect(() => {
-    scroller.current.scrollTo(0, props.currentScrollTops[props.source.path]);
-  }, [props.source.path]);
-
-  useEffect(() => {
     const handleScrollPositionEvent = event => {
       setCurrentScrollTop(event.target.scrollTop);
     };
@@ -173,32 +165,31 @@ const LogViewer = props => {
   }, [totalNrOfLinesInFile]);
 
   useEffect(() => {
-    //Scrolls to bottom of the file on pressing tailswitch and keeps the scroller there if the tailswitch is on.
-    if (tailSwitch) {
-      scroller.current.scrollTo(0, scroller.current.scrollHeight);
-    }
-  }, [
-    tailSwitch,
-    props.logs[props.source.path],
-    props.totalNrOfLinesForFiles[props.source.path]
-  ]);
-
-  useEffect(() => {
     if (tailSwitch && emptyLinesLength > 0) {
-      _getMoreLogLines(
-        props.totalNrOfLinesForFiles[props.source.path] -
-          props.logs[props.source.path].length -
-          2
-      );
+      _getMoreLogLines(totalNrOfLinesInFile - logLinesLength);
     }
   }, [tailSwitch]);
 
+  useEffect(() => {
+    if (tailSwitch) {
+      scroller.current.scrollTo(0, scroller.current.scrollHeight);
+    }
+  }, [tailSwitch, filteredAndHighlightedLines]);
+
+  useEffect(() => {
+    saveCurrentScrollTop(props.dispatch, props.source.path, currentScrollTop);
+  }, [currentScrollTop]);
+
+  useEffect(() => {
+    scroller.current.scrollTo(0, props.currentScrollTops[props.source.path]);
+  }, [props.source.path]);
+
   return (
-    <LogViewerContainer ref={scroller}>
+    <LogViewerContainer ref={scroller} data-is-scrollable="true">
       <LogViewerList
         highlightColor={highlightColor}
         wrapLines={wrapLineOn}
-        lines={filteredAndHighlightedLines}
+        lines={[...filteredAndHighlightedLines]}
         scrollTop={currentScrollTop}
         getMoreLogLines={_getMoreLogLines}
         logLinesLength={logLinesLength}

--- a/src/js/view/ipcListener.js
+++ b/src/js/view/ipcListener.js
@@ -78,7 +78,8 @@ const handleLinesFromBackendCache = (dispatch, { dataToReturn }) => {
     dispatch,
     dataToReturn.sourcePath,
     dataToReturn.newLines,
-    dataToReturn.indexForNewLines
+    dataToReturn.indexForNewLines,
+    dataToReturn.isEndOfFile
   );
 };
 
@@ -115,7 +116,7 @@ export const ipcListener = (store, publisher) => {
         handleError(dispatch, action.data);
         break;
       case 'LINES_NEW':
-        handleNewLines(dispatch, action.data, store.getState());
+        handleNewLines(dispatch, action.data);
         break;
       case 'LOGLINES_FETCHED_FROM_BACKEND_CACHE':
         handleLinesFromBackendCache(dispatch, action.data);

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -96,12 +96,13 @@ export const logViewerReducer = (state = initialState, action) => {
         ? state.totalNrOfLinesForFiles[sourcePath]
         : 0;
       const newTotalLinesLength = totalNrOfLines + lines.length;
+      const _lines = replaceEmptyLinesWithHiddenChar(lines);
 
       return {
         ...state,
         logs: {
           ...state.logs,
-          [sourcePath]: [...logLines, ...lines]
+          [sourcePath]: [...logLines, ..._lines]
         },
         totalNrOfLinesForFiles: {
           ...state.totalNrOfLinesForFiles,
@@ -118,6 +119,8 @@ export const logViewerReducer = (state = initialState, action) => {
         indexForNewLines,
         isEndOfFile
       } = action.data;
+      // If we have the end of the file in newLines, adjusting the index for where the new lines will be inserted
+      // takes away possible empty lines at the end of the file.
       const newIndex = isEndOfFile
         ? state.totalNrOfLinesForFiles[sourcePath] - newLines.length
         : indexForNewLines;

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -91,21 +91,36 @@ export const logViewerReducer = (state = initialState, action) => {
     case 'LOGVIEWER_ADD_LINES': {
       console.log('ADDING');
       const { sourcePath, lines } = action.data;
-      const log = state.logs[sourcePath] ? state.logs[sourcePath] : [];
+      const logLines = state.logs[sourcePath] ? state.logs[sourcePath] : [];
+      const totalNrOfLines = state.totalNrOfLinesForFiles[sourcePath]
+        ? state.totalNrOfLinesForFiles[sourcePath]
+        : 0;
+      const newTotalLinesLength = totalNrOfLines + lines.length;
 
       return {
         ...state,
         logs: {
           ...state.logs,
-          [sourcePath]: [...log, ...lines]
+          [sourcePath]: [...logLines, ...lines]
+        },
+        totalNrOfLinesForFiles: {
+          ...state.totalNrOfLinesForFiles,
+          [sourcePath]: newTotalLinesLength
         }
       };
     }
 
     case 'LOGVIEWER_ADD_LINES_FETCHED_FROM_BACKEND_CACHE': {
       console.log('UPDATE CACHE');
-      const { sourcePath, newLines, indexForNewLines } = action.data;
-
+      const {
+        sourcePath,
+        newLines,
+        indexForNewLines,
+        isEndOfFile
+      } = action.data;
+      const newIndex = isEndOfFile
+        ? state.totalNrOfLinesForFiles[sourcePath] - newLines.length
+        : indexForNewLines;
       return {
         ...state,
         logs: {
@@ -114,7 +129,7 @@ export const logViewerReducer = (state = initialState, action) => {
         },
         indexesForNewLines: {
           ...state.indexesForNewLines,
-          [sourcePath]: indexForNewLines
+          [sourcePath]: newIndex
         }
       };
     }

--- a/src/js/view/reducers/logViewerReducer.test.js
+++ b/src/js/view/reducers/logViewerReducer.test.js
@@ -1,7 +1,5 @@
 import { logViewerReducer } from './logViewerReducer';
-describe('', () => {
-  it('', () => {});
-});
+
 describe('logviewer reducer', () => {
   it('should return the initial state', () => {
     const initialState = {
@@ -28,7 +26,7 @@ describe('logviewer reducer', () => {
     const lines = ['hej1', 'hej2', 'hej3'];
     const expectedState = {
       logs: { test: ['hej1', 'hej2', 'hej3'] },
-      totalNrOfLinesForFiles: {},
+      totalNrOfLinesForFiles: { test: 3 },
       lengthOfInitialLogLineArrays: {},
       lengthOfEmptyLines: {},
       currentScrollTops: {},
@@ -70,17 +68,16 @@ describe('logviewer reducer', () => {
     const lines = ['hej4', 'hej5'];
     const state = {
       logs: { test: ['hej1', 'hej2', 'hej3'] },
-      nrOfLinesInViewer: 5
+      totalNrOfLinesForFiles: { test: 3 }
     };
     const expectedState = {
       logs: { test: ['hej1', 'hej2', 'hej3', 'hej4', 'hej5'] },
-      nrOfLinesInViewer: 5
+      totalNrOfLinesForFiles: { test: 5 }
     };
     const sourcePath = 'test';
-    const followTail = true;
     const action = {
       type: 'LOGVIEWER_ADD_LINES',
-      data: { sourcePath, lines, followTail }
+      data: { sourcePath, lines }
     };
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });


### PR DESCRIPTION
This pr fixes the frontend behaviour of following a file, adapting it to the new frontend cache logic.
The toggle is set to false by default. Toggling it should jump you to the bottom of the file and lock the scrollbar there. You should be able to follow a smaller file, with the whole content in the frontend as well as a larger file with empty lines and loglines in the list.

If you want to scroll up again, toggle it to off manually. It mimics the behaviour in the latest release. I removed the auto toggle when scrolling to and from the bottom which caused some issues. 
Toggling to off and not keeping the scroller at the bottom when the list added rows, was one of them. I would like to figure out how to implement that, but decided to go for the simplest solution for now.