### PR TITLE
#475 Clean the state in settings and topPanel when closing a file

### DIFF
--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -154,6 +154,19 @@ export const clearSource = (dispatch, filePath) => {
       sourcePath: filePath
     }
   });
+
+  dispatch({
+    type: 'TOPPANEL_REMOVE_LOGSETTINGS',
+    data: {
+      sourcePath: filePath
+    }
+  });
+  dispatch({
+    type: 'SETTINGS_REMOVE_LOGSETTINGS',
+    data: {
+      sourcePath: filePath
+    }
+  });
 };
 
 export const hideSnackBar = dispatch => {

--- a/src/js/view/reducers/settingsReducer.js
+++ b/src/js/view/reducers/settingsReducer.js
@@ -61,6 +61,17 @@ export const settingsReducer = (state = initialState, action) => {
         }
       };
     }
+    case 'SETTINGS_REMOVE_LOGSETTINGS': {
+      const { sourcePath } = action.data;
+      const settingsToKeep = {};
+      Object.keys(state.tabSettings).forEach(source => {
+        let settings = state.tabSettings[source];
+        if (source !== sourcePath) {
+          settingsToKeep[source] = settings;
+        }
+      });
+      return { ...state, tabSettings: { ...settingsToKeep } };
+    }
     default:
       return state;
   }

--- a/src/js/view/reducers/topPanelReducer.js
+++ b/src/js/view/reducers/topPanelReducer.js
@@ -57,6 +57,17 @@ export const topPanelReducer = (state = initialState, action) => {
         }
       };
     }
+    case 'TOPPANEL_REMOVE_LOGSETTINGS': {
+      const { sourcePath } = action.data;
+      const settingsToKeep = {};
+      Object.keys(state.settings).forEach(source => {
+        let settings = state.settings[source];
+        if (source !== sourcePath) {
+          settingsToKeep[source] = settings;
+        }
+      });
+      return { ...state, settings: { ...settingsToKeep } };
+    }
     case 'TOP_PANEL_STATE_RESTORE':
       return { ...initialState, ...action.data };
     default:


### PR DESCRIPTION
When closing a file not all states was cleaned up and instead continued to have that file in their state. This is now fixed and will improve a minor bug where the state was saved to disk with an often wrong state which led to the wrong files reopening.