### PR TITLE
#460 Fix filtering issue

### DIFF
--- a/src/js/adapters/fileReader.js
+++ b/src/js/adapters/fileReader.js
@@ -196,6 +196,32 @@ const readDataFromByte = (filePath, startReadFromByte, numberOfBytes) => {
   });
 };
 
+const readFileWithStream = (filePath, filterRegex) => {
+  return new Promise((resolve, reject) => {
+    let out = [];
+    let buffer = '';
+    createReadStream(filePath, {
+      start: 0,
+      encoding: 'utf8'
+    })
+      .on('data', chunk => {
+        let lines = (buffer + chunk).split(/\r?\n/);
+        buffer = lines.pop();
+        for (let i = 0; i < lines.length; ++i) {
+          if (filterRegex.test(lines[i])) {
+            out.push(lines[i]);
+          }
+        }
+      })
+      .on('error', err => {
+        reject(err);
+      })
+      .on('end', () => {
+        resolve(out);
+      });
+  });
+};
+
 const parseByteDataIntoStringArrayWithStartByteOfLines = (
   data,
   start,
@@ -267,6 +293,7 @@ module.exports = {
   stopWatcher,
   stopAllWatchers,
   readDataFromByte,
+  readFileWithStream,
   extractStartByteOfLinesFromByteData,
   parseByteDataIntoStringArray
 };

--- a/src/js/adapters/fileReader.js
+++ b/src/js/adapters/fileReader.js
@@ -196,32 +196,6 @@ const readDataFromByte = (filePath, startReadFromByte, numberOfBytes) => {
   });
 };
 
-const readFileWithStream = (filePath, filterRegex) => {
-  return new Promise((resolve, reject) => {
-    let out = [];
-    let buffer = '';
-    createReadStream(filePath, {
-      start: 0,
-      encoding: 'utf8'
-    })
-      .on('data', chunk => {
-        let lines = (buffer + chunk).split(/\r?\n/);
-        buffer = lines.pop();
-        for (let i = 0; i < lines.length; ++i) {
-          if (filterRegex.test(lines[i])) {
-            out.push(lines[i]);
-          }
-        }
-      })
-      .on('error', err => {
-        reject(err);
-      })
-      .on('end', () => {
-        resolve(out);
-      });
-  });
-};
-
 const parseByteDataIntoStringArrayWithStartByteOfLines = (
   data,
   start,
@@ -293,7 +267,6 @@ module.exports = {
   stopWatcher,
   stopAllWatchers,
   readDataFromByte,
-  readFileWithStream,
   extractStartByteOfLinesFromByteData,
   parseByteDataIntoStringArray
 };

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -264,12 +264,25 @@ const getFilteredLines = async (sender, data) => {
     let [, pattern, flags] = /\/(.*)\/(.*)/.exec(filterRegexString);
     filterRegex = new RegExp(`(${pattern})`, flags);
   }
-  const lines = await fileReader.readFileWithStream(sourcePath, filterRegex);
 
+  const [fileSize] = await getFileInfo(sourcePath);
+  const startFromByte = 0;
+  const { lines } = await fileReader.readDataFromByte(
+    sourcePath,
+    startFromByte,
+    fileSize
+  );
+  let newLines = [];
+  for (let lineIndex in lines) {
+    let line = lines[lineIndex];
+    if (filterRegex && filterRegex.test(line)) {
+      newLines.push(line);
+    }
+  }
   const dataToReturn = {
     sourcePath,
-    filteredLines: lines,
-    lineCount: lines.length
+    filteredLines: newLines,
+    lineCount: newLines.length
   };
 
   const action = {

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -264,25 +264,12 @@ const getFilteredLines = async (sender, data) => {
     let [, pattern, flags] = /\/(.*)\/(.*)/.exec(filterRegexString);
     filterRegex = new RegExp(`(${pattern})`, flags);
   }
+  const lines = await fileReader.readFileWithStream(sourcePath, filterRegex);
 
-  const [fileSize] = await getFileInfo(sourcePath);
-  const startFromByte = 0;
-  const { lines } = await fileReader.readDataFromByte(
-    sourcePath,
-    startFromByte,
-    fileSize
-  );
-  let newLines = [];
-  for (let lineIndex in lines) {
-    let line = lines[lineIndex];
-    if (filterRegex && filterRegex.test(line)) {
-      newLines.push(line);
-    }
-  }
   const dataToReturn = {
     sourcePath,
-    filteredLines: newLines,
-    lineCount: newLines.length
+    filteredLines: lines,
+    lineCount: lines.length
   };
 
   const action = {

--- a/src/js/hiddenWindow/mainScriptOffloader.test.js
+++ b/src/js/hiddenWindow/mainScriptOffloader.test.js
@@ -33,15 +33,6 @@ describe('mainScriptOffLoader', () => {
     ).toEqual(expectedResult);
   });
 
-  it('should return true because filter exists', () => {
-    const filterRegex = new RegExp('bla');
-    const line = 'Line 1: blablabla';
-    const expectedResult = true;
-    expect(
-      filterExistsAndMatchesWithLineOrHasFilterNotBeenSet(filterRegex, line)
-    ).toEqual(expectedResult);
-  });
-
   it('should return length of 0 due to line being undefined', () => {
     const highlightRegex = new RegExp('Hello World');
     const list = new Array(3);

--- a/src/js/view/actions/dispatchActions.js
+++ b/src/js/view/actions/dispatchActions.js
@@ -229,3 +229,19 @@ export const saveCurrentScrollTop = (dispatch, sourcePath, scrollTop) => {
     }
   });
 };
+
+export const addFilteredLines = (
+  dispatch,
+  sourcePath,
+  filteredLines,
+  lineCount
+) => {
+  dispatch({
+    type: 'LOGVIEWER_ADD_FILTERED_LINES',
+    data: {
+      sourcePath,
+      filteredLines,
+      lineCount
+    }
+  });
+};

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -7,7 +7,8 @@ import { parseRegExp } from './helpers/regexHelper';
 import { saveCurrentScrollTop } from '../actions/dispatchActions';
 import {
   fetchNewLinesFromBackendCache,
-  updateLogViewerCache
+  updateLogViewerCache,
+  fetchFilteredLinesFromBackend
 } from './helpers/logHelper';
 
 const LogViewer = props => {
@@ -39,7 +40,10 @@ const LogViewer = props => {
   const [filteredAndHighlightedLines, setLines] = useState([]);
   const [currentScrollTop, setCurrentScrollTop] = useState(0);
 
-  let previousLinesLength = useRef(0); // Used to keep track of how many lines there were last time useEffect was called, for optimizing and only sending the new lines
+  let filterRef = useRef('');
+  let previousFilteredLinesLength = useRef(0);
+  let previousLinesLength = useRef(0);
+  // Used to keep track of how many lines there were last time useEffect was called, for optimizing and only sending the new lines
   const scroller = useRef(); // A ref on the logViewerContainer used to keep track of scroll values.
 
   const _getMoreLogLines = indexForNewLines => {
@@ -56,12 +60,10 @@ const LogViewer = props => {
     IPC messages go through the main process and are stringified,
     but JSON can't serialize RegExes, so toString is used before that.
     For more information see mainScriptOffloader.js */
-    let filterRegex = parseRegExp(filterInput),
-      highlightRegex = parseRegExp(highlightInput);
+    let highlightRegex = parseRegExp(highlightInput);
 
     window.ipcRenderer.send('hiddenWindowMessages', {
       type: 'requestHelpFilterAndHighlightLines',
-      filterRegexString: filterRegex ? filterRegex.toString() : '',
       highlightRegexString: highlightRegex ? highlightRegex.toString() : '',
       path: props.source.path,
       ...args
@@ -88,8 +90,14 @@ const LogViewer = props => {
       props.totalNrOfLinesForFiles[props.source.path] &&
       wholeFileIsNotInFeCache
     ) {
-      const cacheLength = props.totalNrOfLinesForFiles[props.source.path];
-      const startIndex = props.indexesForNewLines[props.source.path];
+      const cacheLength =
+        filterRef.current.length === 0
+          ? props.totalNrOfLinesForFiles[props.source.path]
+          : props.totalNrOfFilteredLines[props.source.path];
+      const startIndex =
+        filterRef.current.length === 0
+          ? props.indexesForNewLines[props.source.path]
+          : 0;
 
       const newCache = updateLogViewerCache(cacheLength).insertRows(
         startIndex,
@@ -113,34 +121,67 @@ const LogViewer = props => {
     };
   }, [
     props.totalNrOfLinesForFiles[props.source.path],
-    props.indexesForNewLines[props.source.path]
+    props.indexesForNewLines[props.source.path],
+    props.totalNrOfFilteredLines[props.source.path]
   ]);
 
   useEffect(() => {
     /* Effect for when a new filter or highlight is applied,
     send the lines to be filtered and highlighted again */
-    if (props.logs[props.source.path]) {
+    let logs;
+    filterRef.current = filterInput;
+
+    if (filterInput.length !== 0) {
+      fetchFilteredLinesFromBackend(
+        props.source.path,
+        parseRegExp(filterInput).toString()
+      );
+      logs = props.filteredLogs[props.source.path];
+    } else {
+      logs = props.logs[props.source.path];
+    }
+
+    if (logs) {
       // Reset the previous lines count, as all lines should be wiped.
+      previousFilteredLinesLength.current = 0;
       previousLinesLength.current = 0;
       sendMessageToHiddenWindow({
-        logs: props.logs[props.source.path]
+        logs
       });
     }
-  }, [filterInput, highlightInput, highlightColor]);
+  }, [filterInput, highlightInput, highlightColor, filterRef.current]);
 
   useEffect(() => {
     // Effect for when new lines are added
-    if (props.logs[props.source.path]) {
+    if (props.logs[props.source.path] && filterInput.length === 0) {
       /* Only send lines one by one if there already are lines set.
       Slice used so only newer lines is sent or the entire array if no lines */
       let newLines = props.logs[props.source.path].slice(
         previousLinesLength.current
       );
+
       sendMessageToHiddenWindow({
         sendLinesOneByOne: previousLinesLength.current > 0 ? true : false,
         logs: newLines
       });
       previousLinesLength.current = props.logs.length;
+    } else if (filterInput.length !== 0) {
+      fetchFilteredLinesFromBackend(
+        props.source.path,
+        parseRegExp(filterInput).toString()
+      );
+
+      let newLines = props.filteredLogs[props.source.path].slice(
+        previousFilteredLinesLength.current
+      );
+
+      sendMessageToHiddenWindow({
+        sendLinesOneByOne:
+          previousFilteredLinesLength.current > 0 ? true : false,
+        logs: newLines
+      });
+
+      previousFilteredLinesLength.current = props.filteredLogs.length;
     }
   }, [props.logs]);
 
@@ -191,6 +232,7 @@ const LogViewer = props => {
         wrapLines={wrapLineOn}
         lines={[...filteredAndHighlightedLines]}
         scrollTop={currentScrollTop}
+        filterInput={filterInput}
         getMoreLogLines={_getMoreLogLines}
         logLinesLength={logLinesLength}
         wholeFileNotInFeCache={emptyLinesLength > 0}
@@ -208,7 +250,10 @@ const mapStateToProps = ({
     totalNrOfLinesForFiles,
     lengthOfEmptyLines,
     currentScrollTops,
-    indexesForNewLines
+    indexesForNewLines,
+    filteredLogs,
+    totalNrOfFilteredLines
+    // indexesForFilteredLines
   },
   logInfoState: { logSizes, lastSeenLogSizes }
 }) => {
@@ -222,7 +267,10 @@ const mapStateToProps = ({
     totalNrOfLinesForFiles,
     lengthOfEmptyLines,
     currentScrollTops,
-    indexesForNewLines
+    indexesForNewLines,
+    filteredLogs,
+    totalNrOfFilteredLines
+    // indexesForFilteredLines
   };
 };
 

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -253,7 +253,6 @@ const mapStateToProps = ({
     indexesForNewLines,
     filteredLogs,
     totalNrOfFilteredLines
-    // indexesForFilteredLines
   },
   logInfoState: { logSizes, lastSeenLogSizes }
 }) => {
@@ -270,7 +269,6 @@ const mapStateToProps = ({
     indexesForNewLines,
     filteredLogs,
     totalNrOfFilteredLines
-    // indexesForFilteredLines
   };
 };
 

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -36,9 +36,6 @@ const LogViewer = props => {
   const emptyLinesLength = props.lengthOfEmptyLines[props.source.path]
     ? props.lengthOfEmptyLines[props.source.path]
     : 0;
-  const filteredLogs = props.filteredLogs[props.source.path]
-    ? props.filteredLogs[props.source.path]
-    : [];
 
   const [filteredAndHighlightedLines, setLines] = useState([]);
   const [currentScrollTop, setCurrentScrollTop] = useState(0);
@@ -123,36 +120,24 @@ const LogViewer = props => {
       );
     };
   }, [
-    filteredLogs,
     props.totalNrOfLinesForFiles[props.source.path],
     props.indexesForNewLines[props.source.path],
     props.totalNrOfFilteredLines[props.source.path]
   ]);
 
-  const fetch = () => {
-    filterRef.current = filterInput;
-    let filterRegex = parseRegExp(filterInput);
-    fetchFilteredLinesFromBackend(
-      props.source.path,
-      filterRegex ? filterRegex.toString() : ''
-    );
-  };
-
-  useEffect(() => {
-    if (filterInput.length !== 0) {
-      fetch();
-    }
-  }, [filterInput]);
-
   useEffect(() => {
     /* Effect for when a new filter or highlight is applied,
     send the lines to be filtered and highlighted again */
     let logs;
+    filterRef.current = filterInput;
+
     if (filterInput.length !== 0) {
-      console.log({ fil: props.filteredLogs[props.source.path], filteredLogs });
-      logs = filteredLogs;
+      fetchFilteredLinesFromBackend(
+        props.source.path,
+        parseRegExp(filterInput).toString()
+      );
+      logs = props.filteredLogs[props.source.path];
     } else {
-      filterRef.current = filterInput;
       logs = props.logs[props.source.path];
     }
 
@@ -164,7 +149,7 @@ const LogViewer = props => {
         logs
       });
     }
-  }, [filterInput, highlightInput, highlightColor, filteredLogs]);
+  }, [filterInput, highlightInput, highlightColor, filterRef.current]);
 
   useEffect(() => {
     // Effect for when new lines are added
@@ -181,8 +166,14 @@ const LogViewer = props => {
       });
       previousLinesLength.current = props.logs.length;
     } else if (filterInput.length !== 0) {
-      fetch();
-      let newLines = filteredLogs.slice(previousFilteredLinesLength.current);
+      fetchFilteredLinesFromBackend(
+        props.source.path,
+        parseRegExp(filterInput).toString()
+      );
+
+      let newLines = props.filteredLogs[props.source.path].slice(
+        previousFilteredLinesLength.current
+      );
 
       sendMessageToHiddenWindow({
         sendLinesOneByOne:
@@ -262,6 +253,7 @@ const mapStateToProps = ({
     indexesForNewLines,
     filteredLogs,
     totalNrOfFilteredLines
+    // indexesForFilteredLines
   },
   logInfoState: { logSizes, lastSeenLogSizes }
 }) => {
@@ -278,6 +270,7 @@ const mapStateToProps = ({
     indexesForNewLines,
     filteredLogs,
     totalNrOfFilteredLines
+    // indexesForFilteredLines
   };
 };
 

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -8,7 +8,7 @@ import { saveCurrentScrollTop } from '../actions/dispatchActions';
 import {
   fetchNewLinesFromBackendCache,
   updateLogViewerCache,
-  debouncedfetchFilteredLinesFromBackend
+  fetchFilteredLinesFromBackend
 } from './helpers/logHelper';
 
 const LogViewer = props => {
@@ -132,7 +132,7 @@ const LogViewer = props => {
   const fetch = () => {
     filterRef.current = filterInput;
     let filterRegex = parseRegExp(filterInput);
-    debouncedfetchFilteredLinesFromBackend(
+    fetchFilteredLinesFromBackend(
       props.source.path,
       filterRegex ? filterRegex.toString() : ''
     );
@@ -148,10 +148,11 @@ const LogViewer = props => {
     /* Effect for when a new filter or highlight is applied,
     send the lines to be filtered and highlighted again */
     let logs;
-    filterRef.current = filterInput;
     if (filterInput.length !== 0) {
+      console.log({ fil: props.filteredLogs[props.source.path], filteredLogs });
       logs = filteredLogs;
     } else {
+      filterRef.current = filterInput;
       logs = props.logs[props.source.path];
     }
 

--- a/src/js/view/components/LogViewer.js
+++ b/src/js/view/components/LogViewer.js
@@ -8,7 +8,7 @@ import { saveCurrentScrollTop } from '../actions/dispatchActions';
 import {
   fetchNewLinesFromBackendCache,
   updateLogViewerCache,
-  fetchFilteredLinesFromBackend
+  debouncedfetchFilteredLinesFromBackend
 } from './helpers/logHelper';
 
 const LogViewer = props => {
@@ -132,7 +132,7 @@ const LogViewer = props => {
   const fetch = () => {
     filterRef.current = filterInput;
     let filterRegex = parseRegExp(filterInput);
-    fetchFilteredLinesFromBackend(
+    debouncedfetchFilteredLinesFromBackend(
       props.source.path,
       filterRegex ? filterRegex.toString() : ''
     );
@@ -148,11 +148,10 @@ const LogViewer = props => {
     /* Effect for when a new filter or highlight is applied,
     send the lines to be filtered and highlighted again */
     let logs;
+    filterRef.current = filterInput;
     if (filterInput.length !== 0) {
-      console.log({ fil: props.filteredLogs[props.source.path], filteredLogs });
       logs = filteredLogs;
     } else {
-      filterRef.current = filterInput;
       logs = props.logs[props.source.path];
     }
 

--- a/src/js/view/components/LogViewerList.js
+++ b/src/js/view/components/LogViewerList.js
@@ -51,8 +51,10 @@ const LogViewerList = props => {
 
   useEffect(() => {
     const startItemIndexinView = listRef.current.getStartItemIndexInView();
-    evaluateNrOfItemsScrolled(startItemIndexinView);
-  }, [props.scrollTop]);
+    if (props.filterInput.length === 0) {
+      evaluateNrOfItemsScrolled(startItemIndexinView);
+    }
+  }, [props.scrollTop, props.filterInput]);
 
   const _onRenderCell = (item, index) => {
     const { highlightColor, shouldWrap } = memoizedLineProps;

--- a/src/js/view/components/TopPanel.js
+++ b/src/js/view/components/TopPanel.js
@@ -51,7 +51,7 @@ class TopPanel extends React.Component {
           <Stack.Item align="center">
             <TextFieldInput
               placeholder="Filter"
-              debounce={300}
+              debounce={222}
               onTextChange={text => {
                 handleFilterInput(this.props.dispatch, { sourcePath, text });
               }}
@@ -61,7 +61,7 @@ class TopPanel extends React.Component {
           <Stack.Item align="center">
             <TextFieldInput
               placeholder="Highlight"
-              debounce={300}
+              debounce={222}
               onTextChange={text => {
                 handleHighlightInput(this.props.dispatch, { sourcePath, text });
               }}

--- a/src/js/view/components/TopPanel.js
+++ b/src/js/view/components/TopPanel.js
@@ -51,7 +51,7 @@ class TopPanel extends React.Component {
           <Stack.Item align="center">
             <TextFieldInput
               placeholder="Filter"
-              debounce={222}
+              debounce={300}
               onTextChange={text => {
                 handleFilterInput(this.props.dispatch, { sourcePath, text });
               }}
@@ -61,7 +61,7 @@ class TopPanel extends React.Component {
           <Stack.Item align="center">
             <TextFieldInput
               placeholder="Highlight"
-              debounce={222}
+              debounce={300}
               onTextChange={text => {
                 handleHighlightInput(this.props.dispatch, { sourcePath, text });
               }}

--- a/src/js/view/components/TopPanel.js
+++ b/src/js/view/components/TopPanel.js
@@ -50,8 +50,14 @@ class TopPanel extends React.Component {
           </Stack.Item>
           <Stack.Item align="center">
             <TextFieldInput
-              placeholder="Filter"
-              debounce={222}
+              disabled={this.props.logSizes[sourcePath] > 10000000}
+              label={'Filter'}
+              placeholder={
+                this.props.logSizes[sourcePath] > 10000000
+                  ? 'File too large'
+                  : 'Filter'
+              }
+              debounce={300}
               onTextChange={text => {
                 handleFilterInput(this.props.dispatch, { sourcePath, text });
               }}
@@ -61,7 +67,8 @@ class TopPanel extends React.Component {
           <Stack.Item align="center">
             <TextFieldInput
               placeholder="Highlight"
-              debounce={222}
+              label={'Highlight'}
+              debounce={300}
               onTextChange={text => {
                 handleHighlightInput(this.props.dispatch, { sourcePath, text });
               }}
@@ -89,12 +96,14 @@ class TopPanel extends React.Component {
 
 const mapStateToProps = ({
   menuState: { openSources, currentSourceHandle },
-  topPanelState: { settings }
+  topPanelState: { settings },
+  logInfoState: { logSizes }
 }) => {
   return {
     currentSourceHandle,
     openSources,
-    settings
+    settings,
+    logSizes
   };
 };
 

--- a/src/js/view/components/common/input/TextFieldInput.js
+++ b/src/js/view/components/common/input/TextFieldInput.js
@@ -33,8 +33,9 @@ class TextFieldInput extends React.Component {
   render() {
     return (
       <TextField
+        disabled={this.props.disabled}
         underlined
-        label={this.props.placeholder}
+        label={this.props.label}
         placeholder={this.props.placeholder}
         value={this.state.input}
         onChange={event => {

--- a/src/js/view/components/helpers/logHelper.js
+++ b/src/js/view/components/helpers/logHelper.js
@@ -40,6 +40,20 @@ export const fetchNewLinesFromBackendCache = (
   sendRequestToBackend(argObj);
 };
 
+export const fetchFilteredLinesFromBackend = (
+  sourcePath,
+  filterRegexString
+) => {
+  const argObj = {
+    function: 'FETCH_FILTERED_LINES_FROM_BACKEND',
+    data: {
+      sourcePath,
+      filterRegexString
+    }
+  };
+  sendRequestToBackend(argObj);
+};
+
 export const updateLogViewerCache = cache_length => {
   const insertRows = (startIndex, newLines) => {
     const updatedCache = new Array(cache_length).fill(undefined, 0);

--- a/src/js/view/components/helpers/logHelper.js
+++ b/src/js/view/components/helpers/logHelper.js
@@ -1,5 +1,6 @@
 import { calculateWrappedHeight } from './measureHelper';
 import { sendRequestToBackend } from 'js/view/ipcPublisher';
+import _ from 'lodash';
 
 export const createHeightReducer = (charSize, elWidth) => {
   return (map, next) => {
@@ -39,6 +40,13 @@ export const fetchNewLinesFromBackendCache = (
   };
   sendRequestToBackend(argObj);
 };
+
+export const debouncedfetchFilteredLinesFromBackend = _.debounce(
+  (path, filterRegexString) => {
+    fetchFilteredLinesFromBackend(path, filterRegexString);
+  },
+  500
+);
 
 export const fetchFilteredLinesFromBackend = (
   sourcePath,

--- a/src/js/view/components/helpers/logHelper.js
+++ b/src/js/view/components/helpers/logHelper.js
@@ -1,6 +1,5 @@
 import { calculateWrappedHeight } from './measureHelper';
 import { sendRequestToBackend } from 'js/view/ipcPublisher';
-import _ from 'lodash';
 
 export const createHeightReducer = (charSize, elWidth) => {
   return (map, next) => {
@@ -40,13 +39,6 @@ export const fetchNewLinesFromBackendCache = (
   };
   sendRequestToBackend(argObj);
 };
-
-export const debouncedfetchFilteredLinesFromBackend = _.debounce(
-  (path, filterRegexString) => {
-    fetchFilteredLinesFromBackend(path, filterRegexString);
-  },
-  500
-);
 
 export const fetchFilteredLinesFromBackend = (
   sourcePath,

--- a/src/js/view/ipcListener.js
+++ b/src/js/view/ipcListener.js
@@ -6,7 +6,8 @@ import {
   increaseSize,
   setLastSeenLogSizeToSize,
   addLinesFetchedFromBackendCache,
-  addCalculatedAmountOfLines
+  addCalculatedAmountOfLines,
+  addFilteredLines
 } from 'js/view/actions/dispatchActions';
 import { sendRequestToBackend } from 'js/view/ipcPublisher';
 import { prettifyErrorMessage } from 'js/view/components/helpers/errorHelper';
@@ -92,6 +93,15 @@ const handleError = (dispatch, { message, error }) => {
   showSnackBar(dispatch, errorMessage, 'error');
 };
 
+const handleFilteredLines = (dispatch, { dataToReturn }) => {
+  addFilteredLines(
+    dispatch,
+    dataToReturn.sourcePath,
+    dataToReturn.filteredLines,
+    dataToReturn.lineCount
+  );
+};
+
 export const ipcListener = (store, publisher) => {
   const dispatch = store.dispatch;
 
@@ -120,6 +130,9 @@ export const ipcListener = (store, publisher) => {
         break;
       case 'LOGLINES_FETCHED_FROM_BACKEND_CACHE':
         handleLinesFromBackendCache(dispatch, action.data);
+        break;
+      case 'LOGLINES_FILTERED':
+        handleFilteredLines(dispatch, action.data);
         break;
       default:
         console.log('Warning: Unrecognized message, ', action);

--- a/src/js/view/reducers/logViewerReducer.js
+++ b/src/js/view/reducers/logViewerReducer.js
@@ -4,7 +4,9 @@ const initialState = {
   lengthOfEmptyLines: {},
   totalNrOfLinesForFiles: {},
   currentScrollTops: {},
-  indexesForNewLines: {}
+  indexesForNewLines: {},
+  filteredLogs: {},
+  totalNrOfFilteredLines: {}
 };
 
 // Invisible character U+2800 being used in line.replace. Making the viewer display empty lines.
@@ -145,6 +147,22 @@ export const logViewerReducer = (state = initialState, action) => {
         currentScrollTops: {
           ...state.currentScrollTops,
           [sourcePath]: scrollTop
+        }
+      };
+    }
+
+    case 'LOGVIEWER_ADD_FILTERED_LINES': {
+      console.log('ADDING FILTERED LINES');
+      const { sourcePath, filteredLines, lineCount } = action.data;
+      return {
+        ...state,
+        filteredLogs: {
+          ...state.filteredLogs,
+          [sourcePath]: filteredLines
+        },
+        totalNrOfFilteredLines: {
+          ...state.totalNrOfFilteredLines,
+          [sourcePath]: lineCount
         }
       };
     }

--- a/src/js/view/reducers/logViewerReducer.test.js
+++ b/src/js/view/reducers/logViewerReducer.test.js
@@ -8,7 +8,9 @@ describe('logviewer reducer', () => {
       lengthOfInitialLogLineArrays: {},
       lengthOfEmptyLines: {},
       currentScrollTops: {},
-      indexesForNewLines: {}
+      indexesForNewLines: {},
+      filteredLogs: {},
+      totalNrOfFilteredLines: {}
     };
     expect(logViewerReducer(undefined, {})).toEqual(initialState);
   });
@@ -30,7 +32,9 @@ describe('logviewer reducer', () => {
       lengthOfInitialLogLineArrays: {},
       lengthOfEmptyLines: {},
       currentScrollTops: {},
-      indexesForNewLines: {}
+      indexesForNewLines: {},
+      filteredLogs: {},
+      totalNrOfFilteredLines: {}
     };
     const sourcePath = 'test';
 
@@ -55,7 +59,9 @@ describe('logviewer reducer', () => {
       lengthOfEmptyLines: {},
       totalNrOfLinesForFiles: {},
       currentScrollTops: { test: 0 },
-      indexesForNewLines: { test: 0 }
+      indexesForNewLines: { test: 0 },
+      filteredLogs: {},
+      totalNrOfFilteredLines: {}
     };
     const action = {
       type: 'LOGVIEWER_SET_LOG',
@@ -81,4 +87,26 @@ describe('logviewer reducer', () => {
     };
     expect(logViewerReducer(state, action)).toEqual(expectedState);
   });
+});
+
+it('should set filtered lines', () => {
+  const sourcePath = 'test';
+  const filteredLines = ['line4', 'line7'];
+  const lineCount = 2;
+
+  const expectedState = {
+    logs: {},
+    totalNrOfLinesForFiles: {},
+    lengthOfInitialLogLineArrays: {},
+    lengthOfEmptyLines: {},
+    currentScrollTops: {},
+    indexesForNewLines: {},
+    filteredLogs: { test: ['line4', 'line7'] },
+    totalNrOfFilteredLines: { test: 2 }
+  };
+  const action = {
+    type: 'LOGVIEWER_ADD_FILTERED_LINES',
+    data: { sourcePath, filteredLines, lineCount }
+  };
+  expect(logViewerReducer(undefined, action)).toEqual(expectedState);
 });


### PR DESCRIPTION
Before this PR only the lines from the cache were being sent through the mainScriptOffLoader for filtering and highlighting. To be able to filter through all the lines in a file,  the parts regarding filtering in the mainScriptOffLoader has been moved to engine. A function to fetch filtered lines has been added to the front-end and is called when the filterInput is not empty. 

See how this works for you, and do write any feedback you might have :).