### PR TITLE
Fix bug that causes Loglady to freeze when opening a file in the new version #526

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 BROWSER=none
+REACT_APP_VERSION=$npm_package_version

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ The script starts with install [Homebrew](https://brew.sh/) and brew formulas wh
 #### Help, the app won't start!
 Some developers have reported problems with the startup-scripts working correctly, but electron refuses to display a window. I.e., running `npm run dev` or starting via F5 in VS Code does not produce an error, but displays `Compiled successfully!` as expected, yet no window is displayed by electron.
 
-This seems to somehow be related to saved appData, and clearing folder `C:\Users\<user>\AppData\Roaming\loglady` is confirmed to have helped.
+This seems to somehow be related to the saved data related to the app. Clearing the folder containing this data is confirmed to have helped. You can find this folder in the following places.
+Windows: `C:\Users\<user>\AppData\Roaming\loglady`
+Mac: `~/Library/Application Support/loglady`
+Linux: `$XDG_CONFIG_HOME` or `~/.config`
 
 #### Using Visual Studio Code (Recommended)
 Simply run the debug configuration using F5. Then, use the [Debug toolbar](https://code.visualstudio.com/docs/editor/debugging#_debug-actions) to stop or restart the application.  

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -10,6 +10,7 @@ const {
   checkIfCacheIsWithinSizeLimit,
   flushCacheForOneFile
 } = require('./cache');
+const { version } = require('../../../package.json');
 
 const updateRecentFiles = recentFiles => {
   createMenu(recentFiles);
@@ -125,12 +126,15 @@ const loadStateFromDisk = async (state, sender) => {
   diskPersistance
     .loadStateFromDisk()
     .then(_data => {
-      const action = {
-        type: 'STATE_SET',
-        data: JSON.parse(_data)
-      };
+      const data = JSON.parse(_data);
+      if (data.version === version.slice(1)) {
+        const action = {
+          type: 'STATE_SET',
+          data: data
+        };
 
-      sender.send(ipcChannel, action);
+        sender.send(ipcChannel, action);
+      }
     })
     .catch(error => {
       if (error.code === 'ENOENT') return;

--- a/src/js/view/configurations/configureStore.js
+++ b/src/js/view/configurations/configureStore.js
@@ -6,6 +6,7 @@ export const configureStore = (store, send = sendRequestToBackend) => {
     send({
       function: 'STATE_SAVE',
       reduxStateValue: JSON.stringify({
+        version: process.env.REACT_APP_VERSION,
         topPanelState,
         settingsState,
         menuState

--- a/src/js/view/configurations/configureStore.test.js
+++ b/src/js/view/configurations/configureStore.test.js
@@ -11,7 +11,8 @@ it('should saveStateToDisk', () => {
     logViewerState: 'one',
     menuState: 'menu',
     topPanelState: 'top',
-    settingsState: 'settings'
+    settingsState: 'settings',
+    version: process.env.REACT_APP_VERSION
   });
 
   const publisher = configureStore(fakeStore, fakeRequester);
@@ -27,7 +28,8 @@ it('should saveStateToDisk', () => {
       reduxStateValue: {
         topPanelState: 'top',
         menuState: 'menu',
-        settingsState: 'settings'
+        settingsState: 'settings',
+        version: process.env.REACT_APP_VERSION
       }
     }
   ]);


### PR DESCRIPTION
We identified this behaviour to be caused by the app trying to load the saved state in reduxState.json. topPanelState and settingsState changed between v.1.2.0 and 1.3.0 when the feature for individual setting for each file was implemented. If the user has the previous object in their reduxState.json the app will not work.

This solution simply adds a version check before loading the state from the disc. The object in reduxState.json is now saved with the current version in a key. 

Let me know how it works for you! Try it out by altering or removing the version value in your reduxState.json.