### PR TITLE
Flush backend cache for one file when closing its tab #527 

### DIFF
--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -348,6 +348,9 @@ const createEventHandler = state => {
           console.error(err);
         });
         break;
+      case 'FLUSH_CACHE_FOR_FILE':
+        flushCacheForOneFile(_argObj.filePath);
+        break;
       default:
     }
   };

--- a/src/js/view/components/helpers/handleFileHelper.js
+++ b/src/js/view/components/helpers/handleFileHelper.js
@@ -5,10 +5,10 @@ export const showOpenDialog = () => {
   sendRequestToBackend({ function: 'DIALOG_OPEN_SHOW' });
 };
 
-export const openFile = (filePath /*, initialAmountOfLines*/) => {
+export const openFile = filePath => {
   sendRequestToBackend({
     function: 'FILE_OPEN',
-    data: { filePath /*, initialAmountOfLines */ }
+    data: { filePath }
   });
 };
 
@@ -19,6 +19,11 @@ export const closeFile = (dispatch, filePath) => {
     filePath
   };
   sendRequestToBackend(argObj);
+  const argObj2 = {
+    function: 'FLUSH_CACHE_FOR_FILE',
+    filePath
+  };
+  sendRequestToBackend(argObj2);
 
   //handle related states on frontend
   clearSource(dispatch, filePath);


### PR DESCRIPTION
This small fix adds a request to the backend when a tab is closed for removing the cached lines of the closed file. That way it does not take up unnecessary space when it's not needed.