### PR TITLE
#531 BUG/ Save state to disc is sometimes not executed on quitting the application

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -139,7 +139,7 @@ const createWindow = async () => {
   );
 
   mainWindow.on('close', () => {
-    const argObj = { type: 'QUIT' };
+    const argObj = { type: 'SAVE_CURRENT_STATE' };
     mainWindow.webContents.send('backendMessages', argObj);
   });
   loadingWindow.show();

--- a/public/electron.js
+++ b/public/electron.js
@@ -138,10 +138,6 @@ const createWindow = async () => {
     path.join(__dirname, '..', '/src/resources/hiddenWindow.html')
   );
 
-  mainWindow.on('close', () => {
-    const argObj = { type: 'SAVE_CURRENT_STATE' };
-    mainWindow.webContents.send('backendMessages', argObj);
-  });
   loadingWindow.show();
 
   mainWindow.on('closed', () => {

--- a/src/js/engine/engine.js
+++ b/src/js/engine/engine.js
@@ -68,6 +68,7 @@ const sendFileOpened = async (
 
   sender.send(ipcChannel, action);
   sendTotalLineCount(filePath, sender);
+  sender.send(ipcChannel, { type: 'SAVE_CURRENT_STATE' });
 };
 
 const sendTotalLineCount = async (filePath, sender) => {
@@ -136,7 +137,7 @@ const loadStateFromDisk = async (state, sender) => {
     .loadStateFromDisk()
     .then(_data => {
       const data = JSON.parse(_data);
-      // slice to skip the v before version nr
+      // slice to skip the v in ex v2.0.0
       if (data.version === version.slice(1)) {
         const action = {
           type: 'STATE_SET',
@@ -387,8 +388,9 @@ const createEventHandler = state => {
           console.error(err);
         });
         break;
-      case 'FLUSH_CACHE_FOR_FILE':
+      case 'ON_TAB_CLOSE':
         flushCacheForOneFile(_argObj.filePath);
+        sender.send(ipcChannel, { type: 'SAVE_CURRENT_STATE' });
         break;
       default:
     }

--- a/src/js/view/components/helpers/handleFileHelper.js
+++ b/src/js/view/components/helpers/handleFileHelper.js
@@ -14,16 +14,17 @@ export const openFile = filePath => {
 
 export const closeFile = (dispatch, filePath) => {
   //send request to backend
-  const argObj = {
+  const argObjUnfollow = {
     function: 'SOURCE_UNFOLLOW',
     filePath
   };
-  sendRequestToBackend(argObj);
-  const argObj2 = {
-    function: 'FLUSH_CACHE_FOR_FILE',
+  sendRequestToBackend(argObjUnfollow);
+
+  const argObjOnTabClose = {
+    function: 'ON_TAB_CLOSE',
     filePath
   };
-  sendRequestToBackend(argObj2);
+  sendRequestToBackend(argObjOnTabClose);
 
   //handle related states on frontend
   clearSource(dispatch, filePath);

--- a/src/js/view/ipcListener.js
+++ b/src/js/view/ipcListener.js
@@ -107,7 +107,7 @@ export const ipcListener = (store, publisher) => {
 
   window.ipcRenderer.on('backendMessages', (_event, action) => {
     switch (action.type) {
-      case 'QUIT':
+      case 'SAVE_CURRENT_STATE':
         publisher.saveStateToDisk();
         break;
       case 'STATE_SET':


### PR DESCRIPTION
Due to what seems like a race condition, the state was not always saved to the disc when closing the application. 
In this fix I trigger saving of the state when opening a file and when closing a tab, to really make sure that the reduxState.json contain the information of what tabs should be opened next time the application is started. Is it a little overkill? Perhaps? Maybe it is enough with just saving it on either of the cases? 
I also changed the name of the 'QUIT' case in ipcListener to 'SAVE_CURRENT_STATE'. It felt odd sending a quit message when opening a file and closing a tab.
Let me know what you think and if it works for you.